### PR TITLE
Implement Reclass reference parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,6 @@ name = "reclass_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+anyhow = "1.0.75"
+nom = "7.1.3"
 pyo3 = "0.19.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
 #![deny(clippy::suspicious)]
+#![warn(clippy::single_match_else)]
+#![warn(clippy::explicit_into_iter_loop)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![warn(clippy::redundant_closure_for_method_calls)]
+#![warn(let_underscore_drop)]
 
 use pyo3::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 #![warn(clippy::redundant_closure_for_method_calls)]
 #![warn(let_underscore_drop)]
 
+mod refs;
+
 use pyo3::prelude::*;
 
 /// Reclass allows configuring various library behaviors

--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -53,6 +53,20 @@ mod test_refs {
     use super::*;
 
     #[test]
+    fn test_parse_no_ref() {
+        let input = "foo-bar-baz";
+        let res = parse_ref(input).unwrap();
+        assert_eq!(res, Token::literal_from_str("foo-bar-baz"))
+    }
+
+    #[test]
+    fn test_parse_escaped_ref() {
+        let input = r"foo-bar-\${baz}";
+        let res = parse_ref(input).unwrap();
+        assert_eq!(res, Token::literal_from_str("foo-bar-${baz}"))
+    }
+
+    #[test]
     fn test_parse_ref() {
         let input = "foo-${bar:baz}";
         let res = parse_ref(input).unwrap();

--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -66,6 +66,33 @@ mod test_refs {
     }
 
     #[test]
+    fn test_parse_nested() {
+        let tstr = "${foo:${bar}}";
+        assert_eq!(
+            parse_ref(tstr).unwrap(),
+            Token::Ref(vec![
+                Token::Literal("foo:".into()),
+                Token::Ref(vec![Token::Literal("bar".into())])
+            ])
+        );
+    }
+
+    #[test]
+    fn test_parse_nested_deep() {
+        let tstr = "${foo:${bar:${foo:baz}}}";
+        assert_eq!(
+            parse_ref(tstr).unwrap(),
+            Token::Ref(vec![
+                Token::Literal("foo:".into()),
+                Token::Ref(vec![
+                    Token::Literal("bar:".into()),
+                    Token::Ref(vec![Token::Literal("foo:baz".into()),])
+                ])
+            ])
+        );
+    }
+
+    #[test]
     fn test_parse_ref_error_1() {
         let input = "foo-${bar";
         let res = parse_ref(input);

--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -1,18 +1,50 @@
 mod parser;
 mod token;
 
-use anyhow::{anyhow, Result};
+use nom::error::{convert_error, VerboseError};
 
 pub use self::token::Token;
 
-#[allow(unused)]
-pub fn parse_ref(input: &str) -> Result<Token> {
-    use self::parser::parse_ref;
-    let (uncons, token) =
-        parse_ref(input).map_err(|e| anyhow!("Error parsing reference: {}", e))?;
-    if !uncons.is_empty() {
-        return Err(anyhow!("Failed to parse '{}': trailing {}", input, uncons));
+#[derive(Debug)]
+pub struct ParseError<'a> {
+    input: &'a str,
+    nom_err: Option<VerboseError<&'a str>>,
+    summary: String,
+}
+
+impl<'a> std::fmt::Display for ParseError<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:\n\n", self.summary)?;
+        if let Some(e) = &self.nom_err {
+            write!(f, "{}", convert_error(self.input, e.clone()))?;
+        }
+        Ok(())
     }
+}
+
+#[allow(unused)]
+pub fn parse_ref(input: &str) -> Result<Token, ParseError> {
+    use self::parser::parse_ref;
+    let (uncons, token) = parse_ref(input).map_err(|e| match e {
+        nom::Err::Error(e) | nom::Err::Failure(e) => ParseError {
+            input,
+            nom_err: Some(e),
+            summary: format!("Error parsing reference '{}'", input),
+        },
+        nom::Err::Incomplete(needed) => ParseError {
+            input,
+            nom_err: None,
+            summary: format!("Failed to parse input, need more data: {needed:?}"),
+        },
+    })?;
+    // uncons can't be empty, since we use the all_consuming combinator in the nom parser, so
+    // trailing data will result in a parse error.
+    if !uncons.is_empty() {
+        panic!(
+            "Trailing data '{}' occurred when parsing '{}', this shouldn't happen! Parsed result: {}",
+            uncons, input, token
+        );
+    };
     Ok(token)
 }
 
@@ -31,5 +63,32 @@ mod test_refs {
                 Token::Ref(vec![Token::Literal("bar:baz".to_owned())])
             ])
         )
+    }
+
+    #[test]
+    fn test_parse_ref_error_1() {
+        let input = "foo-${bar";
+        let res = parse_ref(input);
+        assert!(res.is_err());
+        let e = res.unwrap_err();
+        println!("{}", e);
+    }
+
+    #[test]
+    fn test_parse_ref_error_2() {
+        let input = "foo-${bar}${}";
+        let res = parse_ref(input);
+        assert!(res.is_err());
+        let e = res.unwrap_err();
+        println!("{}", e);
+    }
+
+    #[test]
+    fn test_parse_ref_error_3() {
+        let input = "${foo-${bar}";
+        let res = parse_ref(input);
+        assert!(res.is_err());
+        let e = res.unwrap_err();
+        println!("{}", e);
     }
 }

--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -132,4 +132,25 @@ mod test_refs {
         let e = res.unwrap_err();
         println!("{}", e);
     }
+
+    #[test]
+    fn test_parse_ref_format() {
+        let input = r"foo-${foo:${bar}}-${baz}-\${bar}-\\${qux}";
+        let res = parse_ref(&input).unwrap();
+        assert_eq!(
+            res,
+            Token::Combined(vec![
+                Token::literal_from_str("foo-"),
+                Token::Ref(vec![
+                    Token::literal_from_str("foo:"),
+                    Token::Ref(vec![Token::literal_from_str("bar")])
+                ]),
+                Token::literal_from_str("-"),
+                Token::Ref(vec![Token::literal_from_str("baz")]),
+                Token::literal_from_str(r"-${bar}-\"),
+                Token::Ref(vec![Token::literal_from_str("qux")]),
+            ])
+        );
+        assert_eq!(format!("{}", res), input);
+    }
 }

--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -1,0 +1,35 @@
+mod parser;
+mod token;
+
+use anyhow::{anyhow, Result};
+
+pub use self::token::Token;
+
+#[allow(unused)]
+pub fn parse_ref(input: &str) -> Result<Token> {
+    use self::parser::parse_ref;
+    let (uncons, token) =
+        parse_ref(input).map_err(|e| anyhow!("Error parsing reference: {}", e))?;
+    if !uncons.is_empty() {
+        return Err(anyhow!("Failed to parse '{}': trailing {}", input, uncons));
+    }
+    Ok(token)
+}
+
+#[cfg(test)]
+mod test_refs {
+    use super::*;
+
+    #[test]
+    fn test_parse_ref() {
+        let input = "foo-${bar:baz}";
+        let res = parse_ref(input).unwrap();
+        assert_eq!(
+            res,
+            Token::Combined(vec![
+                Token::Literal("foo-".to_owned()),
+                Token::Ref(vec![Token::Literal("bar:baz".to_owned())])
+            ])
+        )
+    }
+}

--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -50,7 +50,7 @@ pub fn parse_ref(input: &str) -> Result<Token, ParseError> {
     // uncons can't be empty, since we use the all_consuming combinator in the nom parser, so
     // trailing data will result in a parse error.
     if !uncons.is_empty() {
-        panic!(
+        unreachable!(
             "Trailing data '{}' occurred when parsing '{}', this shouldn't happen! Parsed result: {}",
             uncons, input, token
         );

--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -6,9 +6,13 @@ use nom::error::{convert_error, VerboseError};
 pub use self::token::Token;
 
 #[derive(Debug)]
+/// Wraps errors generated when trying to parse a string which may contain Reclass references
 pub struct ParseError<'a> {
+    /// Holds a reference to the original input string
     input: &'a str,
+    /// Holds a `nom::error::VerboseError`, if parsing failed with a `nom::Err::Error` or `nom::Err::Failure`
     nom_err: Option<VerboseError<&'a str>>,
+    /// Holds a human-readable summary of the parse error
     summary: String,
 }
 
@@ -23,6 +27,12 @@ impl<'a> std::fmt::Display for ParseError<'a> {
 }
 
 #[allow(unused)]
+/// Parses the provided input string and emits a `Token` which represents any Reclass references
+/// that were found in the input string.
+///
+/// The function currently doesn't allow customizing the Reclass reference start and end markers,
+/// or the escape character. The default Reclass reference format `${...}` and the default escape
+/// character '\' are recognized by the parser.
 pub fn parse_ref(input: &str) -> Result<Token, ParseError> {
     use self::parser::parse_ref;
     let (uncons, token) = parse_ref(input).map_err(|e| match e {

--- a/src/refs/parser.rs
+++ b/src/refs/parser.rs
@@ -18,12 +18,17 @@ fn coalesce_literals(tokens: Vec<Token>) -> Vec<Token> {
     let mut res = vec![tokiter.next().unwrap()];
     for tok in tokiter {
         if res.last().unwrap().is_literal() && tok.is_literal() {
-            let t = res.pop().unwrap();
-            res.push(Token::Literal(format!(
-                "{}{}",
-                t.as_string(),
-                tok.as_string()
-            )));
+            // TODO(sg): Move the if-let bindings into the if above this comment once the
+            // corresponding Rust feature is stabilized.
+            if let Token::Literal(t) = res.pop().unwrap() {
+                if let Token::Literal(tok) = tok {
+                    res.push(Token::Literal(format!("{}{}", t, tok)));
+                } else {
+                    panic!("this should be unreachable");
+                }
+            } else {
+                panic!("this should be unreachable");
+            }
         } else {
             res.push(tok);
         }

--- a/src/refs/parser.rs
+++ b/src/refs/parser.rs
@@ -24,10 +24,10 @@ fn coalesce_literals(tokens: Vec<Token>) -> Vec<Token> {
                 if let Token::Literal(tok) = tok {
                     res.push(Token::Literal(format!("{}{}", t, tok)));
                 } else {
-                    panic!("this should be unreachable");
+                    unreachable!("Literal token isn't a literal?");
                 }
             } else {
-                panic!("this should be unreachable");
+                unreachable!("Literal token isn't a literal?");
             }
         } else {
             res.push(tok);

--- a/src/refs/parser.rs
+++ b/src/refs/parser.rs
@@ -1,0 +1,497 @@
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take},
+    character::complete::none_of,
+    combinator::{all_consuming, map, not, peek},
+    multi::many1,
+    sequence::{delimited, preceded, tuple},
+    IResult,
+};
+
+use super::token::Token;
+
+fn coalesce_literals(tokens: Vec<Token>) -> Vec<Token> {
+    let mut tokiter = tokens.into_iter();
+    let mut res = vec![tokiter.next().unwrap()];
+    for tok in tokiter {
+        if res.last().unwrap().is_literal() && tok.is_literal() {
+            let t = res.pop().unwrap();
+            res.push(Token::Literal(format!(
+                "{}{}",
+                t.as_string(),
+                tok.as_string()
+            )));
+        } else {
+            res.push(tok);
+        }
+    }
+    res
+}
+
+fn ref_open(input: &str) -> IResult<&str, &str> {
+    tag("${")(input)
+}
+
+fn ref_close(input: &str) -> IResult<&str, &str> {
+    tag("}")(input)
+}
+
+fn ref_escape_open(input: &str) -> IResult<&str, String> {
+    map(preceded(tag("\\"), ref_open), String::from)(input)
+}
+
+fn ref_escape_close(input: &str) -> IResult<&str, String> {
+    map(preceded(tag("\\"), ref_close), String::from)(input)
+}
+
+fn double_escape(input: &str) -> IResult<&str, String> {
+    map(
+        tuple((tag(r"\\"), peek(alt((ref_open, ref_close))))),
+        |_| r"\".to_string(),
+    )(input)
+}
+
+fn ref_not_open(input: &str) -> IResult<&str, ()> {
+    // don't advance parse position, just check for ref_open variants
+    map(
+        tuple((not(tag("${")), not(tag("\\${")), not(tag("\\\\${")))),
+        |(_, _, _)| (),
+    )(input)
+}
+
+fn ref_content(input: &str) -> IResult<&str, String> {
+    fn ref_not_close(input: &str) -> IResult<&str, ()> {
+        // don't advance parse position, just check for ref_close variants
+        map(
+            tuple((not(tag("}")), not(tag("\\}")), not(tag("\\\\}")))),
+            |(_, _, _)| (),
+        )(input)
+    }
+
+    fn ref_text(input: &str) -> IResult<&str, String> {
+        alt((
+            map(many1(none_of("\\${}")), |ch| ch.iter().collect::<String>()),
+            map(tuple((not(tag("}")), take(1usize))), |(_, c): (_, &str)| {
+                c.to_string()
+            }),
+        ))(input)
+    }
+
+    map(
+        tuple((ref_not_open, ref_not_close, ref_text)),
+        |(_, _, t)| t,
+    )(input)
+}
+
+fn ref_string(input: &str) -> IResult<&str, String> {
+    map(
+        many1(alt((
+            double_escape,
+            ref_escape_open,
+            ref_escape_close,
+            ref_content,
+        ))),
+        |s| s.join(""),
+    )(input)
+}
+
+fn ref_item(input: &str) -> IResult<&str, Token> {
+    alt((reference, map(ref_string, Token::Literal)))(input)
+}
+
+fn reference(input: &str) -> IResult<&str, Token> {
+    map(delimited(ref_open, many1(ref_item), ref_close), |tokens| {
+        Token::Ref(coalesce_literals(tokens))
+    })(input)
+}
+
+fn string(input: &str) -> IResult<&str, String> {
+    fn text(input: &str) -> IResult<&str, String> {
+        alt((
+            map(many1(none_of("${}\\")), |ch| ch.iter().collect::<String>()),
+            map(take(1usize), std::string::ToString::to_string),
+        ))(input)
+    }
+
+    fn content(input: &str) -> IResult<&str, String> {
+        map(many1(tuple((ref_not_open, text))), |strings| {
+            strings
+                .iter()
+                .map(|((), s)| s.clone())
+                .collect::<Vec<String>>()
+                .join("")
+        })(input)
+    }
+
+    alt((double_escape, ref_escape_open, content))(input)
+}
+
+fn item(input: &str) -> IResult<&str, Token> {
+    alt((reference, map(string, Token::Literal)))(input)
+}
+
+pub fn parse_ref(input: &str) -> IResult<&str, Token> {
+    map(all_consuming(many1(item)), |tokens| {
+        let tokens = coalesce_literals(tokens);
+        if tokens.len() > 1 {
+            Token::Combined(tokens)
+        } else {
+            tokens.into_iter().next().unwrap()
+        }
+    })(input)
+}
+
+#[cfg(test)]
+mod test_parser_funcs {
+    use super::*;
+
+    #[test]
+    fn test_simple_ref() {
+        assert_eq!(
+            parse_ref(&"${foo}".to_string()),
+            Ok(("", Token::Ref(vec![Token::literal_from_str("foo")])))
+        );
+    }
+
+    #[test]
+    fn test_parse_literal_dollar() {
+        assert_eq!(
+            parse_ref(&"$".to_string()),
+            Ok(("", Token::literal_from_str("$")))
+        );
+    }
+
+    #[test]
+    fn test_parse_escape_in_literal() {
+        assert_eq!(
+            parse_ref(&"foo\\bar".to_string()),
+            Ok(("", Token::literal_from_str("foo\\bar")))
+        );
+    }
+
+    #[test]
+    fn test_parse_literal_dollar_begin() {
+        assert_eq!(
+            parse_ref(&"$foo".to_string()),
+            Ok(("", Token::literal_from_str("$foo"),))
+        );
+    }
+
+    #[test]
+    fn test_parse_literal_double_dollar() {
+        assert_eq!(
+            parse_ref(&"foo$$foo".to_string()),
+            Ok(("", Token::literal_from_str("foo$$foo")))
+        );
+    }
+
+    #[test]
+    fn test_parse_literal_dollar_end() {
+        assert_eq!(
+            parse_ref(&"foo$".to_string()),
+            Ok(("", Token::literal_from_str("foo$")))
+        );
+    }
+
+    #[test]
+    fn test_parse_literal_double_dollar_end() {
+        assert_eq!(
+            parse_ref(&"foo$$".to_string()),
+            Ok(("", Token::literal_from_str("foo$$")))
+        );
+    }
+
+    #[test]
+    fn test_parse_leading_dollar_ref() {
+        let refstr = r#"$${foo}"#.to_string();
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok((
+                "",
+                Token::Combined(vec![
+                    Token::literal_from_str("$"),
+                    Token::Ref(vec![Token::literal_from_str("foo")])
+                ])
+            ))
+        )
+    }
+
+    #[test]
+    fn test_parse_full_string_ref() {
+        assert_eq!(
+            parse_ref(&"${foo:bar:baz}".to_string()),
+            Ok((
+                "",
+                Token::Ref(vec![Token::literal_from_str("foo:bar:baz"),])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_ref_at_start() {
+        assert_eq!(
+            parse_ref(&"${foo}bar".to_string()),
+            Ok((
+                "",
+                Token::Combined(vec![
+                    Token::Ref(vec![Token::literal_from_str("foo")]),
+                    Token::literal_from_str("bar")
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_ref_at_end() {
+        assert_eq!(
+            parse_ref(&"foo${bar}".to_string()),
+            Ok((
+                "",
+                Token::Combined(vec![
+                    Token::literal_from_str("foo"),
+                    Token::Ref(vec![Token::literal_from_str("bar")])
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_ref_followed_by_ref() {
+        assert_eq!(
+            parse_ref(&"${foo}${bar}".to_string()),
+            Ok((
+                "",
+                Token::Combined(vec![
+                    Token::Ref(vec![Token::literal_from_str("foo")]),
+                    Token::Ref(vec![Token::literal_from_str("bar")])
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_interspersed_refs() {
+        assert_eq!(
+            parse_ref(&"a-${foo}-${bar}-b".to_string()),
+            Ok((
+                "",
+                Token::Combined(vec![
+                    Token::literal_from_str("a-"),
+                    Token::Ref(vec![Token::literal_from_str("foo")]),
+                    Token::literal_from_str("-"),
+                    Token::Ref(vec![Token::literal_from_str("bar")]),
+                    Token::literal_from_str("-b")
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_nested_refs() {
+        assert_eq!(
+            parse_ref(&"${foo:${bar}}".to_string()),
+            Ok((
+                "",
+                Token::Ref(vec![
+                    Token::literal_from_str("foo:"),
+                    Token::Ref(vec![Token::literal_from_str("bar")])
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_nested_refs_complex_1() {
+        assert_eq!(
+            parse_ref(&"${foo:${bar}:baz}".to_string()),
+            Ok((
+                "",
+                Token::Ref(vec![
+                    Token::literal_from_str("foo:"),
+                    Token::Ref(vec![Token::literal_from_str("bar")]),
+                    Token::literal_from_str(":baz")
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_nested_refs_complex_2() {
+        assert_eq!(
+            parse_ref(&"${foo:${bar:${baz}}}".to_string()),
+            Ok((
+                "",
+                Token::Ref(vec![
+                    Token::literal_from_str("foo:"),
+                    Token::Ref(vec![
+                        Token::literal_from_str("bar:"),
+                        Token::Ref(vec![Token::literal_from_str("baz")])
+                    ])
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_escaped_ref() {
+        let refstr = r#"\${foo}"#.to_string();
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok(("", Token::literal_from_str("${foo}")))
+        )
+    }
+
+    #[test]
+    fn test_parse_escaped_ref_embedded() {
+        let refstr = r#"pass \${foo}"#.to_string();
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok(("", Token::literal_from_str("pass ${foo}")))
+        )
+    }
+
+    #[test]
+    fn test_parse_double_escaped_ref() {
+        let refstr = r#"\\${foo}"#.to_string();
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok((
+                "",
+                Token::Combined(vec![
+                    Token::literal_from_str("\\"),
+                    Token::Ref(vec![Token::literal_from_str("foo")])
+                ])
+            ))
+        )
+    }
+
+    #[test]
+    fn test_parse_escaped_ref_close() {
+        let refstr = r#"${foo\}}"#.to_string();
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok(("", Token::Ref(vec![Token::literal_from_str("foo}")])))
+        )
+    }
+
+    #[test]
+    fn test_parse_escaped_ref_close_embedded() {
+        let refstr = r#"foo$-${foo\}}-\${bar}"#.to_string();
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok((
+                "",
+                Token::Combined(vec![
+                    Token::literal_from_str("foo$-"),
+                    Token::Ref(vec![Token::literal_from_str("foo}")]),
+                    Token::literal_from_str("-${bar}"),
+                ])
+            ))
+        )
+    }
+
+    #[test]
+    fn test_parse_escaped_escape_close_in_refpath() {
+        let refstr = r#"${foo:${bar\}:${baz}}}"#.to_string();
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok((
+                "",
+                Token::Ref(vec![
+                    Token::literal_from_str("foo:"),
+                    Token::Ref(vec![
+                        Token::literal_from_str("bar}:"),
+                        Token::Ref(vec![Token::literal_from_str("baz")])
+                    ])
+                ])
+            ))
+        )
+    }
+
+    #[test]
+    fn test_parse_embedded_nested_ref() {
+        let refstr = r#"${foo:bar${bar}}"#.to_string();
+
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok((
+                "",
+                Token::Ref(vec![
+                    Token::literal_from_str("foo:bar"),
+                    Token::Ref(vec![Token::literal_from_str("bar")])
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_embedded_nested_ref_escaped() {
+        let refstr = r#"${foo:bar\\${bar}}"#.to_string();
+
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok((
+                "",
+                Token::Ref(vec![
+                    Token::literal_from_str("foo:bar\\"),
+                    Token::Ref(vec![Token::literal_from_str("bar")])
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_incomplete_ref_error() {
+        let refstr = r#"${foo:${bar}"#.to_string();
+
+        let res = parse_ref(&refstr);
+        // TODO(sg): the nom error are currently useless, figure out how to wrap them in nice parse
+        // errors, maybe nom-supreme or some other wrapper/helper crate can help.
+        println!("{:#?}", res);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_parse_incomplete_ref_error_2() {
+        let refstr = r#"${bar}${bar"#.to_string();
+
+        let res = parse_ref(&refstr);
+        println!("{:#?}", res);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_parse_incomplete_ref_escaped() {
+        let refstr = r#"\${foo:${bar}"#.to_string();
+
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok((
+                "",
+                Token::Combined(vec![
+                    Token::literal_from_str("${foo:"),
+                    Token::Ref(vec![Token::literal_from_str("bar")])
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_incomplete_ref_double_escaped_error() {
+        let refstr = r#"\\${foo:${bar}"#.to_string();
+        println!("{}", refstr);
+
+        let res = parse_ref(&refstr);
+        println!("{:#?}", res);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_parse_unmatched_closing_brace() {
+        let refstr = r#"foo}bar"#.to_string();
+        assert_eq!(
+            parse_ref(&refstr),
+            Ok(("", Token::literal_from_str("foo}bar")))
+        );
+    }
+}

--- a/src/refs/token.rs
+++ b/src/refs/token.rs
@@ -35,8 +35,6 @@ impl Token {
 mod test_token {
     use super::*;
 
-    use crate::refs::parse_ref;
-
     #[test]
     fn test_is_ref() {
         assert_eq!(Token::Literal("foo".into()).is_ref(), false);
@@ -52,33 +50,6 @@ mod test_token {
         assert_eq!(
             Token::Ref(vec![Token::Literal("foo".into())]).is_literal(),
             false
-        );
-    }
-
-    #[test]
-    fn test_parse_nested() {
-        let tstr = "${foo:${bar}}";
-        assert_eq!(
-            parse_ref(tstr).unwrap(),
-            Token::Ref(vec![
-                Token::Literal("foo:".into()),
-                Token::Ref(vec![Token::Literal("bar".into())])
-            ])
-        );
-    }
-
-    #[test]
-    fn test_parse_nested_deep() {
-        let tstr = "${foo:${bar:${foo:baz}}}";
-        assert_eq!(
-            parse_ref(tstr).unwrap(),
-            Token::Ref(vec![
-                Token::Literal("foo:".into()),
-                Token::Ref(vec![
-                    Token::Literal("bar:".into()),
-                    Token::Ref(vec![Token::Literal("foo:baz".into()),])
-                ])
-            ])
         );
     }
 }

--- a/src/refs/token.rs
+++ b/src/refs/token.rs
@@ -1,0 +1,84 @@
+#[derive(Debug, PartialEq, Eq)]
+pub enum Token {
+    Literal(String),
+    Ref(Vec<Token>),
+    Combined(Vec<Token>),
+}
+
+impl Token {
+    pub fn as_string(&self) -> String {
+        match self {
+            Token::Literal(s) => s.clone(),
+            Token::Ref(ts) | Token::Combined(ts) => ts.iter().fold(String::new(), |mut st, t| {
+                st.push_str(&t.as_string());
+                st
+            }),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn literal_from_str(l: &str) -> Self {
+        Self::Literal(l.to_string())
+    }
+
+    #[allow(unused)]
+    pub fn is_ref(&self) -> bool {
+        matches!(self, Self::Ref(_))
+    }
+
+    pub fn is_literal(&self) -> bool {
+        matches!(self, Self::Literal(_))
+    }
+}
+
+#[cfg(test)]
+mod test_token {
+    use super::*;
+
+    use crate::refs::parse_ref;
+
+    #[test]
+    fn test_is_ref() {
+        assert_eq!(Token::Literal("foo".into()).is_ref(), false);
+        assert_eq!(
+            Token::Ref(vec![Token::Literal("foo".into())]).is_ref(),
+            true
+        );
+    }
+
+    #[test]
+    fn test_is_literal() {
+        assert_eq!(Token::Literal("foo".into()).is_literal(), true);
+        assert_eq!(
+            Token::Ref(vec![Token::Literal("foo".into())]).is_literal(),
+            false
+        );
+    }
+
+    #[test]
+    fn test_parse_nested() {
+        let tstr = "${foo:${bar}}";
+        assert_eq!(
+            parse_ref(tstr).unwrap(),
+            Token::Ref(vec![
+                Token::Literal("foo:".into()),
+                Token::Ref(vec![Token::Literal("bar".into())])
+            ])
+        );
+    }
+
+    #[test]
+    fn test_parse_nested_deep() {
+        let tstr = "${foo:${bar:${foo:baz}}}";
+        assert_eq!(
+            parse_ref(tstr).unwrap(),
+            Token::Ref(vec![
+                Token::Literal("foo:".into()),
+                Token::Ref(vec![
+                    Token::Literal("bar:".into()),
+                    Token::Ref(vec![Token::Literal("foo:baz".into()),])
+                ])
+            ])
+        );
+    }
+}

--- a/src/refs/token.rs
+++ b/src/refs/token.rs
@@ -1,7 +1,12 @@
 #[derive(Debug, PartialEq, Eq)]
+/// Represents a parsed Reclass reference
 pub enum Token {
+    /// A parsed input string which doesn't contain any Reclass references
     Literal(String),
+    /// A parsed reference
     Ref(Vec<Token>),
+    /// A parsed input string which is composed of one or more references, potentially with
+    /// interspersed non-reference sections.
     Combined(Vec<Token>),
 }
 

--- a/src/refs/token.rs
+++ b/src/refs/token.rs
@@ -6,16 +6,6 @@ pub enum Token {
 }
 
 impl Token {
-    pub fn as_string(&self) -> String {
-        match self {
-            Token::Literal(s) => s.clone(),
-            Token::Ref(ts) | Token::Combined(ts) => ts.iter().fold(String::new(), |mut st, t| {
-                st.push_str(&t.as_string());
-                st
-            }),
-        }
-    }
-
     #[cfg(test)]
     pub fn literal_from_str(l: &str) -> Self {
         Self::Literal(l.to_string())
@@ -28,6 +18,30 @@ impl Token {
 
     pub fn is_literal(&self) -> bool {
         matches!(self, Self::Literal(_))
+    }
+}
+
+impl std::fmt::Display for Token {
+    /// Returns the string representation of the Token.
+    ///
+    /// format!("{}", parse_ref(<input string>)) should result in the original input string.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn flatten(ts: &[Token]) -> String {
+            ts.iter().fold(String::new(), |mut st, t| {
+                st.push_str(&format!("{t}"));
+                st
+            })
+        }
+        match self {
+            Token::Literal(s) => {
+                write!(f, "{}", s.clone().replace('\\', r"\\").replace('$', r"\$"))
+            }
+            Token::Ref(ts) => {
+                let refcontent = flatten(ts);
+                write!(f, "${{{refcontent}}}")
+            }
+            Token::Combined(ts) => write!(f, "{}", flatten(ts)),
+        }
     }
 }
 
@@ -50,6 +64,75 @@ mod test_token {
         assert_eq!(
             Token::Ref(vec![Token::Literal("foo".into())]).is_literal(),
             false
+        );
+    }
+
+    #[test]
+    fn test_format_1() {
+        assert_eq!(
+            format!("{}", Token::Ref(vec![Token::literal_from_str("foo")])),
+            "${foo}".to_owned(),
+        );
+    }
+
+    #[test]
+    fn test_format_2() {
+        assert_eq!(
+            format!(
+                "{}",
+                Token::Combined(vec![
+                    Token::Ref(vec![Token::literal_from_str("foo")]),
+                    Token::literal_from_str("-bar")
+                ])
+            ),
+            "${foo}-bar".to_owned(),
+        );
+    }
+
+    #[test]
+    fn test_format_3() {
+        assert_eq!(
+            format!(
+                "{}",
+                Token::Combined(vec![
+                    Token::Ref(vec![Token::Combined(vec![
+                        Token::Ref(vec![Token::literal_from_str("foo")]),
+                        Token::literal_from_str(":"),
+                        Token::Ref(vec![Token::literal_from_str("bar")])
+                    ])]),
+                    Token::literal_from_str("-bar")
+                ])
+            ),
+            "${${foo}:${bar}}-bar".to_owned(),
+        );
+    }
+
+    #[test]
+    fn test_format_escaped() {
+        assert_eq!(
+            format!(
+                "{}",
+                Token::Combined(vec![
+                    Token::Ref(vec![Token::literal_from_str("foo")]),
+                    Token::literal_from_str("-$bar")
+                ])
+            ),
+            r"${foo}-\$bar".to_owned(),
+        );
+    }
+
+    #[test]
+    fn test_format_double_escaped() {
+        assert_eq!(
+            format!(
+                "{}",
+                Token::Combined(vec![
+                    Token::Ref(vec![Token::literal_from_str("foo")]),
+                    Token::literal_from_str("\\"),
+                    Token::Ref(vec![Token::literal_from_str("bar")])
+                ])
+            ),
+            r"${foo}\\${bar}".to_owned(),
         );
     }
 }


### PR DESCRIPTION
The reference parser is implemented with the [nom] library which allows easily writing parsers through combinator functions. The parser has been implemented by replicating the grammar supported by the Python parser (cf. [`get_ref_parser`]). Notably, the combinator functions are named roughly the same as their corresponding `pyparsing` functions in the Python implementation.

Note that the Rust implementation doesn't yet support inventory queries (default syntax `$[...]`) or custom start and end markers for parameter references. However, the Reclass reference `${...}` parsing should be compatible with the Python parser including the extension which allows nested references and escaping references with `\`.

The parser implementation comes with a large amount of unit tests for edge and corner cases which can appear when working with references.

[nom]: https://docs.rs/nom

[`get_ref_parser`]: https://github.com/kapicorp/reclass/blob/856b34cb77811d665c6346883238d436ac5c4924/reclass/values/parser_funcs.py#L103-L168

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog