### PR TITLE
Implement custom `Mapping` and `Value` types 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ pyo3 = { version = "0.19.2", features = ["chrono"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_yaml = "0.9.25"
 yaml-merge-keys = { version = "0.6.0", features = ["serde_yaml"] }
+
+[dev-dependencies]
+paste = "1.0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 anyhow = "1.0.75"
 chrono = "0.4.28"
+indexmap = "2.0.0"
 nom = "7.1.3"
 pyo3 = { version = "0.19.2", features = ["chrono"] }
 serde = { version = "1.0.188", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 mod list;
 mod node;
 mod refs;
+mod types;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;

--- a/src/node/nodeinfo.rs
+++ b/src/node/nodeinfo.rs
@@ -2,7 +2,8 @@ use chrono::offset::Local;
 use chrono::DateTime;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use serde_yaml::{Mapping, Value};
+
+use crate::types::{Mapping, Value};
 
 /// Contains metadata for a Reclass node's rendered data
 #[pyclass]
@@ -42,7 +43,7 @@ impl NodeInfoMeta {
         }
     }
 
-    /// Generates a serde_yaml::Mapping suitable to use as meta parameter `_reclass_`
+    /// Generates a Mapping suitable to use as meta parameter `_reclass_`
     pub(crate) fn as_reclass(&self) -> Mapping {
         let mut namedata = Mapping::new();
         namedata.insert("full".into(), self.name.clone().into());
@@ -78,7 +79,7 @@ pub struct NodeInfo {
     pub applications: Vec<String>,
     #[pyo3(get)]
     pub classes: Vec<String>,
-    pub parameters: serde_yaml::Mapping,
+    pub parameters: Mapping,
 }
 
 impl From<super::Node> for NodeInfo {
@@ -88,52 +89,9 @@ impl From<super::Node> for NodeInfo {
             reclass: n.meta,
             applications: n.applications.into(),
             classes: n.classes.into(),
-            parameters: n._params,
+            parameters: n.parameters,
         }
     }
-}
-
-/// Converts a serde_yaml::Value into a PyObject
-fn as_py_obj(v: &Value, py: Python<'_>) -> PyResult<PyObject> {
-    let obj = match v {
-        Value::Null => Option::<()>::None.into_py(py),
-        Value::Bool(b) => b.into_py(py),
-        Value::Number(n) => {
-            if n.is_i64() {
-                n.as_i64().unwrap().into_py(py)
-            } else if n.is_u64() {
-                n.as_u64().unwrap().into_py(py)
-            } else if n.is_f64() {
-                n.as_f64().unwrap().into_py(py)
-            } else {
-                unreachable!("as_py_obj: Number isn't a i64, u64, or f64?");
-            }
-        }
-        Value::Sequence(s) => {
-            let mut pyseq = vec![];
-            for v in s.iter() {
-                pyseq.push(as_py_obj(v, py)?);
-            }
-            pyseq.into_py(py)
-        }
-        Value::Mapping(m) => as_py_dict(m, py)?.into(),
-        Value::String(s) => s.into_py(py),
-        _ => todo!("NYI: {v:#?}"),
-    };
-    Ok(obj)
-}
-
-/// Converts a serde_yaml::Mapping into a PyDict
-fn as_py_dict(m: &Mapping, py: Python<'_>) -> PyResult<Py<PyDict>> {
-    let dict = PyDict::new(py);
-
-    for (k, v) in m.iter() {
-        let pyk = as_py_obj(k, py)?;
-        let pyv = as_py_obj(v, py)?;
-        dict.set_item(pyk, pyv)?;
-    }
-
-    Ok(dict.into())
 }
 
 #[pymethods]
@@ -145,7 +103,7 @@ impl NodeInfo {
     /// Returns the NodeInfo `parameters` field as a PyDict
     #[getter]
     fn parameters(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
-        as_py_dict(&self.parameters, py)
+        self.parameters.as_py_dict(py)
     }
 
     /// Returns the NodeInfo data as a PyDict
@@ -175,122 +133,5 @@ impl NodeInfo {
             self.reclass.render_time.format("%c").to_string(),
         )?;
         Ok(dict.into())
-    }
-}
-
-#[cfg(test)]
-mod nodeinfo_tests {
-    use super::*;
-
-    #[test]
-    fn test_as_py_dict() {
-        let m = r#"
-        a: a
-        b: ['b', 'b']
-        c: 3
-        d:
-          d: d
-        e: true
-        "#;
-        let m: serde_yaml::Mapping = serde_yaml::from_str(m).unwrap();
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
-            let d = as_py_dict(&m, py).unwrap();
-            assert!(d.as_ref(py).is_instance_of::<PyDict>());
-            let locals = PyDict::new(py);
-            locals.set_item("d", d).unwrap();
-            py.run(
-                r#"assert d == {"a": "a", "b": ["b", "b"], "c": 3,"d": {"d": "d"}, "e": True} "#,
-                None,
-                Some(locals),
-            )
-            .unwrap();
-        });
-    }
-
-    #[test]
-    fn test_as_py_obj_null() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
-            let pyv = as_py_obj(&Value::Null, py).unwrap();
-            let v = pyv.as_ref(py);
-            assert!(v.is_none());
-        });
-    }
-
-    #[test]
-    fn test_as_py_obj_bool() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
-            let pyb = as_py_obj(&Value::Bool(true), py).unwrap();
-            let b = pyb.as_ref(py);
-            assert!(b.is_instance_of::<pyo3::types::PyBool>());
-            assert!(b.downcast_exact::<pyo3::types::PyBool>().unwrap().is_true());
-        });
-    }
-
-    #[test]
-    fn test_as_py_obj_int() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
-            let nums: Vec<Value> = vec![5.into(), (-2i64).into()];
-            for n in nums {
-                let pyn = as_py_obj(&n, py).unwrap();
-                let n = pyn.as_ref(py);
-                assert!(n.is_instance_of::<pyo3::types::PyInt>());
-                assert!(n
-                    .downcast_exact::<pyo3::types::PyInt>()
-                    .unwrap()
-                    .eq(n.into_py(py))
-                    .unwrap());
-            }
-        });
-    }
-
-    #[test]
-    fn test_as_py_obj_float() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
-            let pyn = as_py_obj(&3.14.into(), py).unwrap();
-            let n = pyn.as_ref(py);
-            assert!(n.is_instance_of::<pyo3::types::PyFloat>());
-            assert!(n
-                .downcast_exact::<pyo3::types::PyFloat>()
-                .unwrap()
-                .eq(3.14.into_py(py))
-                .unwrap());
-        });
-    }
-
-    #[test]
-    fn test_as_py_obj_sequence() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
-            let pys = as_py_obj(&vec![1, 2, 3].into(), py).unwrap();
-            let s = pys.as_ref(py);
-            assert!(s.is_instance_of::<pyo3::types::PyList>());
-            assert!(s
-                .downcast_exact::<pyo3::types::PyList>()
-                .unwrap()
-                .eq(pyo3::types::PyList::new(py, vec![1, 2, 3]))
-                .unwrap());
-        });
-    }
-
-    #[test]
-    fn test_as_py_obj_string() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
-            let pys = as_py_obj(&"hello, world".into(), py).unwrap();
-            let s = pys.as_ref(py);
-            assert!(s.is_instance_of::<pyo3::types::PyString>());
-            assert_eq!(
-                s.downcast_exact::<pyo3::types::PyString>()
-                    .unwrap()
-                    .to_str()
-                    .unwrap(),
-                "hello, world"
-            );
-        });
     }
 }

--- a/src/types/from.rs
+++ b/src/types/from.rs
@@ -1,18 +1,25 @@
 use super::{Mapping, Value};
 
 impl From<&str> for Value {
+    /// Converts a string slice into a `Value::String`.
     fn from(s: &str) -> Self {
         Self::String(s.to_string())
     }
 }
 
 impl From<String> for Value {
+    /// Converts a String into a `Value::String`.
     fn from(s: String) -> Self {
         Self::String(s)
     }
 }
 
 impl From<serde_yaml::Value> for Value {
+    /// Converts a `serde_yaml::Value` into a `Value`.
+    ///
+    /// `serde_yaml::Value::String` is always converted into `Value::String`.
+    ///
+    /// `serde_yaml::Tagged` values are not supported yet.
     fn from(v: serde_yaml::Value) -> Self {
         match v {
             serde_yaml::Value::Null => Self::Null,
@@ -35,6 +42,11 @@ impl From<serde_yaml::Value> for Value {
 }
 
 impl From<Value> for serde_yaml::Value {
+    /// Converts a `Value` into a `serde_yaml::Value`.
+    ///
+    /// `Value::String` and `Value::Literal` are both converted to `serde_yaml::Value::String`.
+    ///
+    /// `Value::ValueList` is converted to `serde_yaml::Value::Sequence`.
     fn from(v: Value) -> Self {
         match v {
             Value::Null => Self::Null,
@@ -42,7 +54,7 @@ impl From<Value> for serde_yaml::Value {
             Value::Number(n) => Self::Number(n),
             Value::String(s) => Self::String(s),
             Value::Literal(s) => Self::String(s),
-            Value::Sequence(s) => {
+            Value::Sequence(s) | Value::ValueList(s) => {
                 let mut seq: Vec<serde_yaml::Value> = Vec::with_capacity(s.len());
                 for v in s {
                     seq.push(serde_yaml::Value::from(v));
@@ -50,17 +62,18 @@ impl From<Value> for serde_yaml::Value {
                 Self::Sequence(seq)
             }
             Value::Mapping(m) => Self::Mapping(serde_yaml::Mapping::from(m)),
-            Value::ValueList(_) => todo!(),
         }
     }
 }
 
 impl From<Mapping> for Value {
+    /// Converts a `Mapping` into a `Value::Mapping`.
     fn from(value: Mapping) -> Self {
         Value::Mapping(value)
     }
 }
 impl From<serde_yaml::Mapping> for Value {
+    /// Converts a `serde_yaml::Mapping` into a `Value::Mapping`
     fn from(value: serde_yaml::Mapping) -> Self {
         Value::Mapping(value.into())
     }
@@ -86,7 +99,7 @@ from_number! {
 }
 
 impl<T: Into<Value>> From<Vec<T>> for Value {
-    /// Convert a `Vec` into a `Value::Sequence`
+    /// Converts a `Vec` into a `Value::Sequence`.
     ///
     /// This implementation works for any `Vec<T>` whose element type can be converted into a
     /// `Value`.
@@ -96,7 +109,7 @@ impl<T: Into<Value>> From<Vec<T>> for Value {
 }
 
 impl<'a, T: Clone + Into<Value>> From<&'a [T]> for Value {
-    /// Convert a slice into a `Value::Sequence`
+    /// Converts a slice into a `Value::Sequence`.
     ///
     /// This implementation works for any slice `&[T]` whose element type can be converted into a
     /// `Value`.

--- a/src/types/from.rs
+++ b/src/types/from.rs
@@ -1,0 +1,106 @@
+use super::{Mapping, Value};
+
+impl From<&str> for Value {
+    fn from(s: &str) -> Self {
+        Self::String(s.to_string())
+    }
+}
+
+impl From<String> for Value {
+    fn from(s: String) -> Self {
+        Self::String(s)
+    }
+}
+
+impl From<serde_yaml::Value> for Value {
+    fn from(v: serde_yaml::Value) -> Self {
+        match v {
+            serde_yaml::Value::Null => Self::Null,
+            serde_yaml::Value::Bool(b) => Self::Bool(b),
+            serde_yaml::Value::Number(n) => Self::Number(n),
+            serde_yaml::Value::String(s) => Self::String(s),
+            serde_yaml::Value::Sequence(s) => {
+                let mut seq: Vec<Value> = Vec::with_capacity(s.len());
+                for v in s {
+                    seq.push(Value::from(v));
+                }
+                Self::Sequence(seq)
+            }
+            serde_yaml::Value::Mapping(m) => Self::Mapping(Mapping::from(m)),
+            serde_yaml::Value::Tagged(_) => {
+                todo!("Tagged YAML values are not supported yet");
+            }
+        }
+    }
+}
+
+impl From<Value> for serde_yaml::Value {
+    fn from(v: Value) -> Self {
+        match v {
+            Value::Null => Self::Null,
+            Value::Bool(b) => Self::Bool(b),
+            Value::Number(n) => Self::Number(n),
+            Value::String(s) => Self::String(s),
+            Value::Literal(s) => Self::String(s),
+            Value::Sequence(s) => {
+                let mut seq: Vec<serde_yaml::Value> = Vec::with_capacity(s.len());
+                for v in s {
+                    seq.push(serde_yaml::Value::from(v));
+                }
+                Self::Sequence(seq)
+            }
+            Value::Mapping(m) => Self::Mapping(serde_yaml::Mapping::from(m)),
+            Value::ValueList(_) => todo!(),
+        }
+    }
+}
+
+impl From<Mapping> for Value {
+    fn from(value: Mapping) -> Self {
+        Value::Mapping(value)
+    }
+}
+impl From<serde_yaml::Mapping> for Value {
+    fn from(value: serde_yaml::Mapping) -> Self {
+        Value::Mapping(value.into())
+    }
+}
+
+// inspired by serde_yaml::Value, saves us some repetition
+macro_rules! from_number {
+    ($($ty:ident)*) => {
+        $(
+            impl From<$ty> for Value {
+                fn from(n: $ty) -> Self {
+                    Value::Number(n.into())
+                }
+            }
+        )*
+    }
+}
+
+from_number! {
+    i8 i16 i32 i64 isize
+    u8 u16 u32 u64 usize
+    f32 f64
+}
+
+impl<T: Into<Value>> From<Vec<T>> for Value {
+    /// Convert a `Vec` into a `Value::Sequence`
+    ///
+    /// This implementation works for any `Vec<T>` whose element type can be converted into a
+    /// `Value`.
+    fn from(value: Vec<T>) -> Self {
+        Value::Sequence(value.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<'a, T: Clone + Into<Value>> From<&'a [T]> for Value {
+    /// Convert a slice into a `Value::Sequence`
+    ///
+    /// This implementation works for any slice `&[T]` whose element type can be converted into a
+    /// `Value`.
+    fn from(value: &'a [T]) -> Self {
+        Value::Sequence(value.iter().cloned().map(Into::into).collect())
+    }
+}

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -2,6 +2,8 @@
 
 use anyhow::Result;
 use indexmap::IndexMap;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
@@ -102,6 +104,19 @@ impl Mapping {
     #[inline]
     pub fn len(&self) -> usize {
         self.map.len()
+    }
+
+    /// Converts the `Mapping` into a `PyDict`
+    pub fn as_py_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let dict = PyDict::new(py);
+
+        for (k, v) in self.iter() {
+            let pyk = k.as_py_obj(py)?;
+            let pyv = v.as_py_obj(py)?;
+            dict.set_item(pyk, pyv)?;
+        }
+
+        Ok(dict.into())
     }
 }
 

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -1,0 +1,200 @@
+// This implementation is inspired by `serde_yaml::Mapping`
+
+use anyhow::Result;
+use indexmap::IndexMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use super::value::Value;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Mapping {
+    map: IndexMap<Value, Value>,
+    const_keys: Vec<Value>,
+}
+
+impl Mapping {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            map: IndexMap::with_capacity(capacity),
+            const_keys: vec![],
+        }
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.map.reserve(additional);
+    }
+
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.map.shrink_to_fit();
+        self.const_keys.shrink_to_fit();
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.const_keys.clear();
+    }
+
+    #[inline]
+    pub fn insert(&mut self, k: Value, v: Value) -> Option<Value> {
+        self.map.insert(k, v)
+    }
+
+    /// Returns a double-ended iterator visiting all key-value pairs in order of
+    /// insertion. Iterator element type is `(&'a Value, &'a Value)`.
+    #[inline]
+    pub fn iter(&self) -> Iter {
+        Iter {
+            iter: self.map.iter(),
+        }
+    }
+
+    #[inline]
+    pub fn as_map(&self) -> &IndexMap<Value, Value> {
+        &self.map
+    }
+
+    #[inline]
+    pub fn as_map_mut(&mut self) -> &mut IndexMap<Value, Value> {
+        &mut self.map
+    }
+
+    #[inline]
+    pub fn contains_key(&self, k: &Value) -> bool {
+        self.map.contains_key(k)
+    }
+
+    #[inline]
+    pub fn get(&self, k: &Value) -> Option<&Value> {
+        self.map.get(k)
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, k: &Value) -> Option<&mut Value> {
+        self.map.get_mut(k)
+    }
+
+    #[inline]
+    pub fn entry(&mut self, k: Value) -> indexmap::map::Entry<Value, Value> {
+        self.map.entry(k)
+    }
+
+    #[inline]
+    pub fn remove(&mut self, k: &Value) -> Option<Value> {
+        self.map.remove(k)
+    }
+
+    #[inline]
+    pub fn remove_entry(&mut self, k: &Value) -> Option<(Value, Value)> {
+        self.map.remove_entry(k)
+    }
+
+    /// Returns the number of key-value pairs in the map
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+}
+
+impl From<serde_yaml::Mapping> for Mapping {
+    fn from(m: serde_yaml::Mapping) -> Self {
+        let mut new = Self::with_capacity(m.len());
+        for (k, v) in m {
+            new.insert(Value::from(k), Value::from(v));
+        }
+        new
+    }
+}
+
+impl From<Mapping> for serde_yaml::Mapping {
+    fn from(m: Mapping) -> Self {
+        let mut new = Self::with_capacity(m.map.len());
+        for (k, v) in m.map {
+            new.insert(serde_yaml::Value::from(k), serde_yaml::Value::from(v));
+        }
+        new
+    }
+}
+
+impl std::str::FromStr for Mapping {
+    type Err = anyhow::Error;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self> {
+        let m = serde_yaml::from_str::<serde_yaml::Mapping>(s)?;
+        Ok(Self::from(m))
+    }
+}
+
+impl FromIterator<(Value, Value)> for Mapping {
+    // TODO(sg): handle const keys here
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = (Value, Value)>>(iter: I) -> Self {
+        Mapping {
+            map: IndexMap::from_iter(iter),
+            const_keys: vec![],
+        }
+    }
+}
+
+/// Iterator over `&reclass_rs::types::mapping::Mapping`.
+pub struct Iter<'a> {
+    iter: indexmap::map::Iter<'a, Value, Value>,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'a Value, &'a Value);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a> ExactSizeIterator for Iter<'a> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<'a> IntoIterator for &'a Mapping {
+    type Item = (&'a Value, &'a Value);
+    type IntoIter = Iter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        Iter {
+            iter: self.map.iter(),
+        }
+    }
+}
+
+impl Hash for Mapping {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Hash the kv pairs in a way that is not sensitive to their order.
+        // NOTE(sg): Implementation idea copied from serde_yaml's Mapping implementation
+        let mut xor = 0;
+        for (k, v) in self {
+            let mut hasher = DefaultHasher::new();
+            k.hash(&mut hasher);
+            v.hash(&mut hasher);
+            xor ^= hasher.finish();
+        }
+        xor.hash(state);
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,32 @@
+mod from;
+pub(crate) mod mapping;
+mod value;
+
+pub use mapping::Mapping;
+pub use value::Value;
+
+pub type Sequence = Vec<Value>;
+
+/// Represents special key types in Reclass
+#[derive(Debug)]
+enum KeyPrefix {
+    /// Represents a key which is marked as constant
+    ///
+    /// Constant keys can't be overridden any more.
+    Constant, // '=',
+    /// Represents a key which should be overridden instead of merged
+    ///
+    /// Keys prefixed with the override marker are taken as the new base value, discarding any
+    /// previous content of the key.
+    Override, // '~',
+}
+
+impl KeyPrefix {
+    fn from(c: char) -> Option<Self> {
+        match c {
+            '=' => Some(Self::Constant),
+            '~' => Some(Self::Override),
+            _ => None,
+        }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,10 +5,11 @@ mod value;
 pub use mapping::Mapping;
 pub use value::Value;
 
+/// A YAML sequence in which the elements are `reclass_rs::value::Value`
 pub type Sequence = Vec<Value>;
 
 /// Represents special key types in Reclass
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 enum KeyPrefix {
     /// Represents a key which is marked as constant
     ///

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -1,5 +1,6 @@
 // Inspired by `serde_yaml::Value`
 
+use pyo3::prelude::*;
 use serde_yaml::Number;
 use std::hash::{Hash, Hasher};
 use std::mem;
@@ -250,6 +251,37 @@ impl Value {
         }
     }
 
+    /// Converts the `Value` into a `PyObject`
+    pub fn as_py_obj(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let obj = match self {
+            Value::Literal(s) | Value::String(s) => s.into_py(py),
+            Value::Bool(b) => b.into_py(py),
+            Value::Number(n) => {
+                if n.is_i64() {
+                    n.as_i64().unwrap().into_py(py)
+                } else if n.is_u64() {
+                    n.as_u64().unwrap().into_py(py)
+                } else if n.is_f64() {
+                    n.as_f64().unwrap().into_py(py)
+                } else {
+                    Option::<()>::None.into_py(py)
+                }
+            }
+            Value::Sequence(s) => {
+                let mut pyseq = vec![];
+                for v in s.iter() {
+                    pyseq.push(v.as_py_obj(py)?);
+                }
+                pyseq.into_py(py)
+            }
+            Value::Mapping(m) => m.as_py_dict(py)?.into(),
+            Value::Null => Option::<()>::None.into_py(py),
+            // ValueList should never get emitted to Python
+            Value::ValueList(_) => unreachable!(),
+        };
+        Ok(obj)
+    }
+
     pub(super) fn strip_prefix(&self) -> (Self, Option<KeyPrefix>) {
         match self {
             Self::String(s) => {
@@ -265,5 +297,99 @@ impl Value {
             }
             _ => (self.clone(), None),
         }
+    }
+}
+
+#[cfg(test)]
+mod value_tests {
+    use super::*;
+    #[test]
+    fn test_as_py_obj_null() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let pyv = Value::Null.as_py_obj(py).unwrap();
+            let v = pyv.as_ref(py);
+            assert!(v.is_none());
+        });
+    }
+
+    #[test]
+    fn test_as_py_obj_bool() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let pyb = Value::Bool(true).as_py_obj(py).unwrap();
+            let b = pyb.as_ref(py);
+            assert!(b.is_instance_of::<pyo3::types::PyBool>());
+            assert!(b.downcast_exact::<pyo3::types::PyBool>().unwrap().is_true());
+        });
+    }
+
+    #[test]
+    fn test_as_py_obj_int() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let nums: Vec<Value> = vec![5.into(), (-2i64).into()];
+            for n in nums {
+                let pyn = n.as_py_obj(py).unwrap();
+                let n = pyn.as_ref(py);
+                assert!(n.is_instance_of::<pyo3::types::PyInt>());
+                assert!(n
+                    .downcast_exact::<pyo3::types::PyInt>()
+                    .unwrap()
+                    .eq(n.into_py(py))
+                    .unwrap());
+            }
+        });
+    }
+
+    #[test]
+    fn test_as_py_obj_float() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let n: Value = 3.14.into();
+            let pyn = n.as_py_obj(py).unwrap();
+            let n = pyn.as_ref(py);
+            assert!(n.is_instance_of::<pyo3::types::PyFloat>());
+            assert!(n
+                .downcast_exact::<pyo3::types::PyFloat>()
+                .unwrap()
+                .eq(3.14.into_py(py))
+                .unwrap());
+        });
+    }
+
+    #[test]
+    fn test_as_py_obj_sequence() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let s: Value = vec![1, 2, 3].into();
+            let pys = s.as_py_obj(py).unwrap();
+            let s = pys.as_ref(py);
+            assert!(s.is_instance_of::<pyo3::types::PyList>());
+            assert!(s
+                .downcast_exact::<pyo3::types::PyList>()
+                .unwrap()
+                .eq(pyo3::types::PyList::new(py, vec![1, 2, 3]))
+                .unwrap());
+        });
+    }
+
+    #[test]
+    fn test_as_py_obj_string() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let pys = std::convert::Into::<Value>::into("hello, world")
+                .as_py_obj(py)
+                .unwrap();
+            let s = pys.as_ref(py);
+            assert!(s.is_instance_of::<pyo3::types::PyString>());
+            assert_eq!(
+                s.downcast_exact::<pyo3::types::PyString>()
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+                "hello, world"
+            );
+        });
     }
 }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -1,0 +1,269 @@
+// Inspired by `serde_yaml::Value`
+
+use serde_yaml::Number;
+use std::hash::{Hash, Hasher};
+use std::mem;
+
+use super::KeyPrefix;
+use super::{Mapping, Sequence};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Value {
+    /// Represents a YAML `null` value
+    Null,
+    /// Represents a YAML boolean value
+    Bool(bool),
+    /// Represents an unparsed string value which may contain reclass
+    /// references.
+    String(String),
+    /// Represents a string literal value which can't contain reclass
+    /// references.
+    Literal(String),
+    /// Represents a YAML number
+    Number(Number),
+    /// Represents a YAML mapping
+    Mapping(Mapping),
+    /// Represents a YAML sequence
+    Sequence(Sequence),
+    /// ValueList represents a list of layered values which may have different
+    /// types.  ValueLists are flattened during reference interpolation.
+    ValueList(Sequence),
+}
+
+impl Eq for Value {}
+
+impl Hash for Value {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        mem::discriminant(self).hash(state);
+        match self {
+            Self::Null => {}
+            Self::Bool(v) => v.hash(state),
+            Self::Number(v) => v.hash(state),
+            Self::String(v) => v.hash(state),
+            Self::Sequence(v) => v.hash(state),
+            Self::Mapping(v) => v.hash(state),
+            Self::ValueList(v) => v.hash(state),
+            Self::Literal(v) => v.hash(state),
+        }
+    }
+}
+
+impl Default for Value {
+    fn default() -> Self {
+        Self::Null
+    }
+}
+
+impl Value {
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        matches!(self, Self::Null)
+    }
+
+    #[inline]
+    pub fn is_bool(&self) -> bool {
+        matches!(self, Self::Bool(_))
+    }
+
+    #[inline]
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            Self::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_i64(&self) -> bool {
+        match self {
+            Self::Number(n) => n.is_i64(),
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            Self::Number(n) => n.as_i64(),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_u64(&self) -> bool {
+        match self {
+            Self::Number(n) => n.is_u64(),
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn as_u64(&self) -> Option<u64> {
+        match self {
+            Self::Number(n) => n.as_u64(),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_f64(&self) -> bool {
+        match self {
+            Self::Number(n) => n.is_f64(),
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            Self::Number(n) => n.as_f64(),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_string(&self) -> bool {
+        matches!(self, Self::String(_))
+    }
+
+    #[inline]
+    pub fn is_literal(&self) -> bool {
+        matches!(self, Self::Literal(_))
+    }
+
+    #[inline]
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::String(s) => Some(s),
+            Self::Literal(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_mapping(&self) -> bool {
+        matches!(self, Self::Mapping(_))
+    }
+
+    #[inline]
+    pub fn as_mapping(&self) -> Option<&Mapping> {
+        match self {
+            Self::Mapping(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_mapping_mut(&mut self) -> Option<&mut Mapping> {
+        match self {
+            Self::Mapping(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_sequence(&self) -> bool {
+        matches!(self, Self::Sequence(_))
+    }
+
+    #[inline]
+    pub fn as_sequence(&self) -> Option<&Sequence> {
+        match self {
+            Self::Sequence(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_sequence_mut(&mut self) -> Option<&mut Sequence> {
+        match self {
+            Self::Sequence(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_value_list(&self) -> bool {
+        matches!(self, Self::ValueList(_))
+    }
+
+    #[inline]
+    pub fn as_value_list(&self) -> Option<&Sequence> {
+        match self {
+            Self::ValueList(l) => Some(l),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_value_list_mut(&mut self) -> Option<&mut Sequence> {
+        match self {
+            Self::ValueList(l) => Some(l),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, k: &Value) -> Option<&Value> {
+        match self {
+            Self::Mapping(m) => m.get(k),
+            Self::Sequence(s) | Self::ValueList(s) => {
+                if let Some(idx) = k.as_u64() {
+                    let idx = idx as usize;
+                    if idx < s.len() {
+                        return Some(&s[idx]);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, k: &Value) -> Option<&mut Value> {
+        match self {
+            Self::Mapping(m) => m.get_mut(k),
+            Self::Sequence(s) | Self::ValueList(s) => {
+                if let Some(idx) = k.as_u64() {
+                    let idx = idx as usize;
+                    if idx < s.len() {
+                        return Some(&mut s[idx]);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn variant(&self) -> &str {
+        match self {
+            Self::Bool(_) => "Value::Bool",
+            Self::Mapping(_) => "Value::Mapping",
+            Self::Null => "Value::Null",
+            Self::Number(_) => "Value::Number",
+            Self::Sequence(_) => "Value::Sequence",
+            Self::String(_) => "Value::String",
+            Self::Literal(_) => "Value::Literal",
+            Self::ValueList(_) => "Value::ValueList",
+        }
+    }
+
+    pub(super) fn strip_prefix(&self) -> (Self, Option<KeyPrefix>) {
+        match self {
+            Self::String(s) => {
+                if s.is_empty() {
+                    return (self.clone(), None);
+                }
+                let p = KeyPrefix::from(s.chars().next().unwrap());
+                if p.is_some() {
+                    (Self::String(s[1..].to_string()), p)
+                } else {
+                    (self.clone(), None)
+                }
+            }
+            _ => (self.clone(), None),
+        }
+    }
+}

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -305,6 +305,283 @@ impl Value {
 #[cfg(test)]
 mod value_tests {
     use super::*;
+    use paste::paste;
+
+    #[test]
+    fn test_is_null() {
+        assert!(Value::Null.is_null());
+        assert!(!Value::Bool(true).is_null());
+    }
+
+    #[test]
+    fn test_is_bool() {
+        assert!(!Value::Null.is_bool());
+        assert!(Value::Bool(true).is_bool());
+    }
+
+    #[test]
+    fn test_as_bool() {
+        let b = Value::Bool(true);
+        assert_eq!(b.as_bool(), Some(true));
+        assert_eq!(Value::Null.as_bool(), None);
+    }
+
+    macro_rules! test_number {
+        ($($ty:ident $val:expr)*) => {
+            $(
+                paste! {
+                #[test]
+                fn [<test_is_ $ty>]() {
+                    assert!(!Value::Null.[<is_ $ty>]());
+                    let n: $ty = $val;
+                    let n = Value::Number(n.into());
+                    assert!(n.[<is_ $ty>]());
+                }
+
+                #[test]
+                fn [<test_as_ $ty>]() {
+                    assert_eq!(Value::Null.[<as_ $ty>](), None);
+                    let n: $ty = $val;
+                    let n = Value::Number(n.into());
+                    assert_eq!(n.[<as_ $ty>](), Some($val));
+                }
+                }
+            )*
+        }
+    }
+    test_number! { u64 5 i64 -3 f64 3.14 }
+
+    #[test]
+    fn test_is_string() {
+        assert!(!Value::Null.is_string());
+        let s = Value::from("foo");
+        assert!(s.is_string());
+        assert!(!s.is_literal());
+    }
+
+    #[test]
+    fn test_is_literal() {
+        assert!(!Value::Null.is_literal());
+        let s = Value::Literal("foo".into());
+        assert!(s.is_literal());
+        assert!(!s.is_string());
+    }
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(Value::Null.as_str(), None);
+
+        let s = Value::Literal("foo".into());
+        assert_eq!(s.as_str(), Some("foo"));
+
+        let s = Value::from("foo");
+        assert_eq!(s.as_str(), Some("foo"));
+    }
+
+    #[test]
+    fn test_is_mapping() {
+        assert!(!Value::Null.is_mapping());
+        let m = Value::from(Mapping::new());
+        assert!(m.is_mapping());
+    }
+
+    #[test]
+    fn test_as_mapping() {
+        assert_eq!(Value::Null.as_mapping(), None);
+        let m = Value::from(Mapping::new());
+        assert_eq!(m.as_mapping(), Some(&Mapping::new()));
+    }
+
+    #[test]
+    fn test_as_mapping_mut() {
+        assert_eq!(Value::Null.as_mapping_mut(), None);
+        let mut m = Value::from(Mapping::new());
+        let map = m.as_mapping_mut().unwrap();
+        map.insert("foo".into(), "bar".into());
+        assert_eq!(
+            m.as_mapping(),
+            Some(&Mapping::from_iter(vec![("foo".into(), "bar".into())]))
+        );
+    }
+
+    #[test]
+    fn test_is_sequence() {
+        assert!(!Value::Null.is_sequence());
+        let s = Value::from(Sequence::new());
+        assert!(s.is_sequence());
+    }
+
+    #[test]
+    fn test_as_sequence() {
+        assert_eq!(Value::Null.as_sequence(), None);
+        let s = Value::from(Sequence::new());
+        assert_eq!(s.as_sequence(), Some(&Sequence::new()));
+    }
+
+    #[test]
+    fn test_as_sequence_mut() {
+        assert_eq!(Value::Null.as_sequence_mut(), None);
+        let mut s = Value::from(Sequence::new());
+        let seq = s.as_sequence_mut().unwrap();
+        seq.push("foo".into());
+        assert_eq!(
+            s.as_sequence(),
+            Some(&Sequence::from_iter(vec!["foo".into()]))
+        );
+    }
+
+    #[test]
+    fn test_is_value_list() {
+        assert!(!Value::Null.is_value_list());
+        let l = Value::ValueList(Sequence::new());
+        assert!(l.is_value_list());
+    }
+
+    #[test]
+    fn test_as_value_list() {
+        assert_eq!(Value::Null.as_value_list(), None);
+        let l = Value::ValueList(Sequence::new());
+        assert_eq!(l.as_value_list(), Some(&Sequence::new()));
+    }
+
+    #[test]
+    fn test_as_value_list_mut() {
+        assert_eq!(Value::Null.as_value_list_mut(), None);
+        let mut l = Value::ValueList(Sequence::new());
+        let seq = l.as_value_list_mut().unwrap();
+        seq.push("foo".into());
+        assert_eq!(
+            l.as_value_list(),
+            Some(&Sequence::from_iter(vec!["foo".into()]))
+        );
+    }
+
+    #[test]
+    fn test_get_mapping() {
+        let m = Mapping::from_iter(vec![("a".into(), 1.into()), (2.into(), "foo".into())]);
+        let m = Value::from(m);
+
+        assert_eq!(m.get(&"a".into()), Some(&1.into()));
+        assert_eq!(m.get(&2.into()), Some(&"foo".into()));
+        assert_eq!(m.get(&"b".into()), None);
+    }
+
+    #[test]
+    fn test_get_mut_mapping() {
+        let m = Mapping::from_iter(vec![("a".into(), 1.into())]);
+        let mut m = Value::from(m);
+
+        assert_eq!(m.get(&"a".into()), Some(&1.into()));
+        let a = m.get_mut(&"a".into()).unwrap();
+        *a = "foo".into();
+        assert_eq!(m.get(&"a".into()), Some(&"foo".into()));
+        assert_eq!(m.get_mut(&"b".into()), None);
+    }
+
+    #[test]
+    fn test_get_sequence() {
+        let s = Sequence::from_iter(vec!["a".into(), 2.into(), 3.14.into()]);
+        let s = Value::from(s);
+
+        // non-u64 and out of bounds accesses return None
+        assert_eq!(s.get(&(-1).into()), None);
+        assert_eq!(s.get(&3.14.into()), None);
+        assert_eq!(s.get(&3.into()), None);
+
+        // non-number accesses return None
+        assert_eq!(s.get(&"foo".into()), None);
+
+        assert_eq!(s.get(&0.into()), Some(&"a".into()));
+        assert_eq!(s.get(&1.into()), Some(&2.into()));
+        assert_eq!(s.get(&2.into()), Some(&3.14.into()));
+    }
+
+    #[test]
+    fn test_get_mut_sequence() {
+        let s = Sequence::from_iter(vec!["a".into(), 2.into(), 3.14.into()]);
+        let mut s = Value::from(s);
+
+        assert_eq!(s.get(&0.into()), Some(&"a".into()));
+        let e0 = s.get_mut(&0.into()).unwrap();
+        *e0 = "foo".into();
+        assert_eq!(s.get(&0.into()), Some(&"foo".into()));
+        assert_eq!(s.get_mut(&3.into()), None);
+    }
+
+    #[test]
+    fn test_get_valuelist() {
+        let s = Sequence::from_iter(vec!["a".into(), 2.into(), 3.14.into()]);
+        let l = Value::ValueList(s);
+
+        // non-u64 and out of bounds accesses return None
+        assert_eq!(l.get(&(-1).into()), None);
+        assert_eq!(l.get(&3.14.into()), None);
+        assert_eq!(l.get(&3.into()), None);
+
+        // non-number accesses return None
+        assert_eq!(l.get(&"foo".into()), None);
+
+        assert_eq!(l.get(&0.into()), Some(&"a".into()));
+        assert_eq!(l.get(&1.into()), Some(&2.into()));
+        assert_eq!(l.get(&2.into()), Some(&3.14.into()));
+    }
+
+    #[test]
+    fn test_get_mut_valuelist() {
+        let s = Sequence::from_iter(vec!["a".into(), 2.into(), 3.14.into()]);
+        let mut l = Value::ValueList(s);
+
+        assert_eq!(l.get(&0.into()), Some(&"a".into()));
+        let e0 = l.get_mut(&0.into()).unwrap();
+        *e0 = "foo".into();
+        assert_eq!(l.get(&0.into()), Some(&"foo".into()));
+        assert_eq!(l.get_mut(&3.into()), None);
+    }
+
+    #[test]
+    fn test_get_other_types() {
+        assert_eq!(Value::Null.get(&"a".into()), None);
+        assert_eq!(Value::Bool(true).get(&"a".into()), None);
+        assert_eq!(Value::String("foo".into()).get(&"a".into()), None);
+        // Strings can't be treated as sequences
+        assert_eq!(Value::String("foo".into()).get(&0.into()), None);
+        assert_eq!(Value::Literal("foo".into()).get(&"a".into()), None);
+        assert_eq!(Value::Number(1.into()).get(&"a".into()), None);
+    }
+
+    #[test]
+    fn test_get_mut_other_types() {
+        assert_eq!(Value::Null.get_mut(&"a".into()), None);
+        assert_eq!(Value::Bool(true).get_mut(&"a".into()), None);
+        assert_eq!(Value::String("foo".into()).get_mut(&"a".into()), None);
+        // Strings can't be treated as sequences
+        assert_eq!(Value::String("foo".into()).get_mut(&0.into()), None);
+        assert_eq!(Value::Literal("foo".into()).get_mut(&"a".into()), None);
+        assert_eq!(Value::Number(1.into()).get_mut(&"a".into()), None);
+    }
+
+    #[test]
+    fn test_strip_prefix() {
+        let k1 = Value::from("=foo");
+        let k2 = Value::from("~foo");
+        let k3 = Value::from("foo");
+        let k4 = Value::from(3);
+        assert_eq!(
+            k1.strip_prefix(),
+            (Value::from("foo"), Some(KeyPrefix::Constant))
+        );
+        assert_eq!(
+            k2.strip_prefix(),
+            (Value::from("foo"), Some(KeyPrefix::Override))
+        );
+        assert_eq!(k3.strip_prefix(), (Value::from("foo"), None));
+        assert_eq!(k4.strip_prefix(), (Value::from(3), None));
+    }
+}
+
+#[cfg(test)]
+mod value_as_py_obj_tests {
+    use super::*;
     #[test]
     fn test_as_py_obj_null() {
         pyo3::prepare_freethreaded_python();

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -238,6 +238,7 @@ impl Value {
         }
     }
 
+    #[allow(unused)]
     pub(crate) fn variant(&self) -> &str {
         match self {
             Self::Bool(_) => "Value::Bool",
@@ -282,6 +283,7 @@ impl Value {
         Ok(obj)
     }
 
+    #[allow(unused)]
     pub(super) fn strip_prefix(&self) -> (Self, Option<KeyPrefix>) {
         match self {
             Self::String(s) => {


### PR DESCRIPTION
This PR introduces custom `Mapping` and `Value` types which are compatible with `serde_yaml`'s types, but provide extra state and functionality for handling the Reclass parameters Mapping.

The PR updates the Node parsing implementation to convert the raw parsed `parameters` into our custom `Mapping` type, and moves the logic which injects the `_reclass_` meta parameter from the raw serde_yaml parameters Mapping to the custom `Mapping`.

Additionally, we move the `as_py_dict()` and `as_py_obj()` methods to the custom `Mapping` and `Value` types respectivey, and remove the variants which take serde_yaml types as parameters.

Finally, we update `NodeInfo` to use the custom `Mapping` type for `parameters`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
