### PR TITLE
Add support for constant keys in our Mapping type

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -98,8 +98,9 @@ impl Node {
 
         // Convert serde_yaml::Mapping into our own Mapping type
         let mut params: Mapping = n._params.clone().into();
-        // Inject `_reclass_` meta parameter into parameters
-        params.insert("_reclass_".into(), n.meta.as_reclass().into());
+        // Inject `_reclass_` meta parameter into parameters, return an error if someone has marked
+        // `_reclass_` or a subkey of it as constant.
+        params.insert("_reclass_".into(), n.meta.as_reclass().into())?;
         n.parameters = params;
 
         Ok(n)

--- a/src/node/nodeinfo.rs
+++ b/src/node/nodeinfo.rs
@@ -45,18 +45,24 @@ impl NodeInfoMeta {
 
     /// Generates a Mapping suitable to use as meta parameter `_reclass_`
     pub(crate) fn as_reclass(&self) -> Mapping {
-        let mut namedata = Mapping::new();
-        namedata.insert("full".into(), self.name.clone().into());
-        namedata.insert(
-            "parts".into(),
-            Value::Sequence(vec![self.name.clone().into()]),
-        );
-        namedata.insert("path".into(), self.name.clone().into());
-        namedata.insert("short".into(), self.name.clone().into());
+        let namedata: Vec<(Value, Value)> = vec![
+            ("full".into(), self.name.clone().into()),
+            (
+                "parts".into(),
+                Value::Sequence(vec![self.name.clone().into()]),
+            ),
+            ("path".into(), self.name.clone().into()),
+            ("short".into(), self.name.clone().into()),
+        ];
+        let namedata = Mapping::from_iter(namedata);
 
         let mut pmeta = Mapping::new();
-        pmeta.insert("environment".into(), self.environment.clone().into());
-        pmeta.insert("name".into(), Value::Mapping(namedata));
+        pmeta
+            .insert("environment".into(), self.environment.clone().into())
+            .unwrap();
+        pmeta
+            .insert("name".into(), Value::Mapping(namedata))
+            .unwrap();
 
         pmeta
     }


### PR DESCRIPTION
We implement handling of constant keys (keys prefixed with `KeyPrefix::Constant`) directly in the Mapping implementation. Keys with other prefixes are inserted into the map unchanged.

To make the implementation more streamlined (and potentially faster), we switch the type of `const_keys` to be a `HashSet` instead of a `Vec`, which gives us `O(1)` removal of elements (for `Mapping::remove()`).

To insure integrity of the constant key tracking, We remove the `map_as_mut()` method on the Mapping implementation which would allow callers to break the constant key invariants that the other functions provide.

Some functions (`insert`, `get_mut`, and `entry`) will return an Error value when called for a key that's marked constant.

Follow-up to #8
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
