### PR TITLE
Clean up format strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,13 @@ impl Reclass {
     }
 
     fn __repr__(&self) -> String {
-        format!("{:#?}", self)
+        format!("{self:#?}")
     }
 
     /// Returns the rendered data for the node with the provided name if it exists
     pub fn nodeinfo(&self, nodename: &str) -> PyResult<NodeInfo> {
-        let n = Node::parse(self, nodename).map_err(|e| {
-            PyValueError::new_err(format!("Error while processing {}: {}", nodename, e))
-        })?;
+        let n = Node::parse(self, nodename)
+            .map_err(|e| PyValueError::new_err(format!("Error while parsing {nodename}: {e}")))?;
         Ok(n.into())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(clippy::redundant_closure_for_method_calls)]
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![warn(clippy::single_match_else)]
+#![warn(clippy::uninlined_format_args)]
 #![warn(let_underscore_drop)]
 
 mod list;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![deny(clippy::suspicious)]
-#![warn(clippy::single_match_else)]
 #![warn(clippy::explicit_into_iter_loop)]
-#![warn(clippy::semicolon_if_nothing_returned)]
 #![warn(clippy::redundant_closure_for_method_calls)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+#![warn(clippy::single_match_else)]
 #![warn(let_underscore_drop)]
 
 mod list;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -39,10 +39,8 @@ const SUPPORTED_YAML_EXTS: [&str; 2] = ["yml", "yaml"];
 
 /// Loads data from `<npath>.yml` or `<npath>.yaml`.
 fn load_file(npath: &Path) -> Result<(String, PathBuf)> {
-    let mut ncontents: Result<(String, PathBuf)> = Err(anyhow!(format!(
-        "Node `{}.ya?ml` not found",
-        npath.display()
-    )));
+    let mut ncontents: Result<(String, PathBuf)> =
+        Err(anyhow!("Node `{}.ya?ml` not found", npath.display()));
     // Try both `.yml` and `.yaml` for both nodes and classes. Prefer `.yml` if both exist.
     for ext in SUPPORTED_YAML_EXTS {
         let np = npath.with_extension(ext);

--- a/src/node/nodeinfo.rs
+++ b/src/node/nodeinfo.rs
@@ -71,7 +71,7 @@ impl NodeInfoMeta {
 #[pymethods]
 impl NodeInfoMeta {
     fn __repr__(&self) -> String {
-        format!("{:#?}", self)
+        format!("{self:#?}")
     }
 }
 
@@ -103,7 +103,7 @@ impl From<super::Node> for NodeInfo {
 #[pymethods]
 impl NodeInfo {
     fn __repr__(&self) -> String {
-        format!("{:#?}", self)
+        format!("{self:#?}")
     }
 
     /// Returns the NodeInfo `parameters` field as a PyDict

--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -39,7 +39,7 @@ pub fn parse_ref(input: &str) -> Result<Token, ParseError> {
         nom::Err::Error(e) | nom::Err::Failure(e) => ParseError {
             input,
             nom_err: Some(e),
-            summary: format!("Error parsing reference '{}'", input),
+            summary: format!("Error parsing reference '{input}'"),
         },
         nom::Err::Incomplete(needed) => ParseError {
             input,

--- a/src/refs/parser.rs
+++ b/src/refs/parser.rs
@@ -22,7 +22,7 @@ fn coalesce_literals(tokens: Vec<Token>) -> Vec<Token> {
             // corresponding Rust feature is stabilized.
             if let Token::Literal(t) = res.pop().unwrap() {
                 if let Token::Literal(tok) = tok {
-                    res.push(Token::Literal(format!("{}{}", t, tok)));
+                    res.push(Token::Literal(format!("{t}{tok}")));
                 } else {
                     unreachable!("Literal token isn't a literal?");
                 }

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -165,7 +165,7 @@ impl Mapping {
             Ok(self.map.insert(k, v))
         } else if self.const_keys.contains(&k) {
             // k is marked constant and already set in the map, return error
-            Err(anyhow!(format!("Can't overwrite constant key {}", k)))
+            Err(anyhow!("Can't overwrite constant key {k}"))
         } else {
             // here: we know the key is present, and not yet marked constant
 
@@ -257,7 +257,7 @@ impl Mapping {
         if !self.const_keys.contains(k) {
             Ok(self.map.get_mut(k))
         } else {
-            Err(anyhow!(format!("Key {} is marked constant", k)))
+            Err(anyhow!("Key {k} is marked constant"))
         }
     }
 
@@ -268,7 +268,7 @@ impl Mapping {
         if !self.const_keys.contains(&k) {
             Ok(self.map.entry(k))
         } else {
-            Err(anyhow!(format!("Key {} is marked constant", k)))
+            Err(anyhow!("Key {k} is marked constant"))
         }
     }
 

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -49,7 +49,7 @@ impl std::fmt::Display for Mapping {
             if i > 0 {
                 write!(f, ", ")?;
             }
-            write!(f, "{}: {}", k, v)?;
+            write!(f, "{k}: {v}")?;
         }
         write!(f, "}}")
     }
@@ -396,7 +396,7 @@ impl FromIterator<(Value, Value)> for Mapping {
         let mut new = Mapping::new();
         for (k, v) in iter {
             if let Err(e) = new.insert(k, v) {
-                eprintln!("Error inserting key-value pair: {}", e);
+                eprintln!("Error inserting key-value pair: {e}");
             }
         }
         new

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -61,20 +61,20 @@ impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Null => write!(f, "Null"),
-            Self::Bool(b) => write!(f, "{}", b),
-            Self::Number(n) => write!(f, "{}", n),
-            Self::String(s) | Self::Literal(s) => write!(f, "\"{}\"", s),
+            Self::Bool(b) => write!(f, "{b}"),
+            Self::Number(n) => write!(f, "{n}"),
+            Self::String(s) | Self::Literal(s) => write!(f, "\"{s}\""),
             Self::Sequence(seq) | Self::ValueList(seq) => {
                 write!(f, "[")?;
                 for (i, v) in seq.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}", v)?;
+                    write!(f, "{v}")?;
                 }
                 write!(f, "]")
             }
-            Self::Mapping(m) => write!(f, "{}", m),
+            Self::Mapping(m) => write!(f, "{m}"),
         }
     }
 }


### PR DESCRIPTION
Removes redundant `format!()` calls in the `anyhow!()` macro which supports format strings, and updates all format strings to use inlined references where possible.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
