### PR TITLE
Enable `clippy::pedantic` lints but allow some included lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 #![deny(clippy::suspicious)]
-#![warn(clippy::explicit_into_iter_loop)]
-#![warn(clippy::redundant_closure_for_method_calls)]
-#![warn(clippy::semicolon_if_nothing_returned)]
-#![warn(clippy::single_match_else)]
-#![warn(clippy::uninlined_format_args)]
+#![warn(clippy::pedantic)]
 #![warn(let_underscore_drop)]
+// Allows need to be after warn/deny
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::similar_names)]
 
 mod list;
 mod node;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -90,7 +90,7 @@ impl Node {
         let p = merge_keys_serde(serde_yaml::Value::from(n._params))?
             .as_mapping()
             .unwrap()
-            .to_owned();
+            .clone();
         n._params = p;
 
         // Convert serde_yaml::Mapping into our own Mapping type

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -24,7 +24,7 @@ pub struct Node {
     pub classes: UniqueList,
     /// Reclass parameters for this node as parsed from YAML
     #[serde(default, rename = "parameters")]
-    _params: serde_yaml::Mapping,
+    params: serde_yaml::Mapping,
     /// Reclass parameters for this node converted into our own mapping type
     #[serde(skip)]
     parameters: Mapping,
@@ -86,15 +86,15 @@ impl Node {
         classes.shrink_to_fit();
         n.classes = classes;
 
-        // Resolve YAML merge keys in `_params`
-        let p = merge_keys_serde(serde_yaml::Value::from(n._params))?
+        // Resolve YAML merge keys in `params`
+        let p = merge_keys_serde(serde_yaml::Value::from(n.params))?
             .as_mapping()
             .unwrap()
             .clone();
-        n._params = p;
+        n.params = p;
 
         // Convert serde_yaml::Mapping into our own Mapping type
-        n.parameters = n._params.clone().into();
+        n.parameters = n.params.clone().into();
 
         Ok(n)
     }
@@ -356,7 +356,7 @@ mod node_tests {
         );
         let mut params = serde_yaml::Mapping::new();
         params.insert(serde_yaml::Value::from("foo"), serde_yaml::Value::from(foo));
-        assert_eq!(n._params, params);
+        assert_eq!(n.params, params);
     }
 
     #[test]
@@ -376,7 +376,7 @@ mod node_tests {
           bar: bar
         "#;
         let expected: serde_yaml::Mapping = serde_yaml::from_str(expected).unwrap();
-        assert_eq!(n._params, expected);
+        assert_eq!(n.params, expected);
     }
 
     #[test]
@@ -398,7 +398,7 @@ mod node_tests {
             bar: bar
         "#;
         let expected: serde_yaml::Mapping = serde_yaml::from_str(expected).unwrap();
-        assert_eq!(n._params, expected);
+        assert_eq!(n.params, expected);
     }
 
     #[test]
@@ -426,7 +426,7 @@ mod node_tests {
           - a: a
         "#;
         let expected: serde_yaml::Mapping = serde_yaml::from_str(expected).unwrap();
-        assert_eq!(n._params, expected);
+        assert_eq!(n.params, expected);
     }
 
     #[test]

--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -200,7 +200,7 @@ fn interpolate_token_slice(tokens: &[Token], params: &Mapping) -> Result<String>
     // Additionally, we repeatedly call `Value::interpolate()` on the resolved value for each
     // element, as long as that Value is a `Value::String`.
     let mut res = String::new();
-    for t in tokens.iter() {
+    for t in tokens {
         let mut v = t.resolve(params)?;
         while v.is_string() {
             v = v.interpolate(params)?;

--- a/src/refs/parser.rs
+++ b/src/refs/parser.rs
@@ -164,11 +164,7 @@ fn string(input: &str) -> IResult<&str, String, VerboseError<&str>> {
         context(
             "content",
             map(many1(tuple((ref_not_open, text))), |strings| {
-                strings
-                    .iter()
-                    .map(|((), s)| s.clone())
-                    .collect::<Vec<String>>()
-                    .join("")
+                strings.iter().map(|((), s)| s.clone()).collect::<String>()
             }),
         )(input)
     }

--- a/src/types/from.rs
+++ b/src/types/from.rs
@@ -52,8 +52,7 @@ impl From<Value> for serde_yaml::Value {
             Value::Null => Self::Null,
             Value::Bool(b) => Self::Bool(b),
             Value::Number(n) => Self::Number(n),
-            Value::String(s) => Self::String(s),
-            Value::Literal(s) => Self::String(s),
+            Value::Literal(s) | Value::String(s) => Self::String(s),
             Value::Sequence(s) | Value::ValueList(s) => {
                 let mut seq: Vec<serde_yaml::Value> = Vec::with_capacity(s.len());
                 for v in s {

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -303,7 +303,7 @@ impl Mapping {
     pub fn as_py_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
         let dict = PyDict::new(py);
 
-        for (k, v) in self.iter() {
+        for (k, v) in self {
             let pyk = k.as_py_obj(py)?;
             let pyv = v.as_py_obj(py)?;
             dict.set_item(pyk, pyv)?;
@@ -345,7 +345,7 @@ impl Mapping {
     /// Mapping. Mapping keys are inserted into the new mapping unchanged.
     pub(super) fn interpolate(&self, root: &Self) -> Result<Self> {
         let mut res = Self::new();
-        for (k, v) in self.iter() {
+        for (k, v) in self {
             let mut v = v.interpolate(root)?;
             v.flatten()?;
             res.insert(k.clone(), v)?;

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -58,12 +58,14 @@ impl std::fmt::Display for Mapping {
 impl Mapping {
     /// Creates a new mapping.
     #[inline]
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Creates a new mapping with the given initial capacity.
     #[inline]
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             map: IndexMap::with_capacity(capacity),
@@ -226,6 +228,7 @@ impl Mapping {
     /// Returns a double-ended iterator visiting all key-value pairs in order of
     /// insertion. Iterator element type is `(&'a Value, &'a Value)`.
     #[inline]
+    #[must_use]
     pub fn iter(&self) -> Iter {
         Iter {
             iter: self.map.iter(),
@@ -234,18 +237,21 @@ impl Mapping {
 
     /// Returns a reference to the underlying `IndexMap`.
     #[inline]
+    #[must_use]
     pub fn as_map(&self) -> &IndexMap<Value, Value> {
         &self.map
     }
 
     /// Returns `true` if the mapping contains key `k`.
     #[inline]
+    #[must_use]
     pub fn contains_key(&self, k: &Value) -> bool {
         self.map.contains_key(k)
     }
 
     /// Returns a reference to the value for key `k` if the key is present in the mapping.
     #[inline]
+    #[must_use]
     pub fn get(&self, k: &Value) -> Option<&Value> {
         self.map.get(k)
     }
@@ -290,11 +296,13 @@ impl Mapping {
 
     /// Returns the number of key-value pairs in the map.
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.map.len()
     }
 
     /// Checks if the map is empty
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.map.len() == 0
     }
@@ -312,10 +320,14 @@ impl Mapping {
         Ok(dict.into())
     }
 
+    /// Checks if the provided key is marked as constant.
+    #[must_use]
     fn is_const(&self, k: &Value) -> bool {
         self.const_keys.contains(k)
     }
 
+    /// Checks if the provided key is marked as overriding.
+    #[must_use]
     fn is_override(&self, k: &Value) -> bool {
         self.override_keys.contains(k)
     }

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -185,13 +185,13 @@ impl Mapping {
 
                 // Create new ValueList for `k` if necessary, and return the old value for `k` if
                 // we had to create a ValueList
-                let oldv = if !self.map.get(&k).unwrap().is_value_list() {
-                    // Replace current value in map with an empty ValueList, and store the old
-                    // value in `oldv`.
-                    self.map.insert(k.clone(), Value::ValueList(vec![]))
-                } else {
-                    // Store `None` in `oldv`, if we didn't have to create a new ValueList.
+                let oldv = if self.map.get(&k).unwrap().is_value_list() {
+                    // Store `None` in `oldv`, if k is already a ValueList.
                     None
+                } else {
+                    // If k isn't a ValueList yet, replace current value in map with an empty
+                    // ValueList, and store the old value in `oldv`.
+                    self.map.insert(k.clone(), Value::ValueList(vec![]))
                 };
 
                 // Get a mutable reference to the underlying Vec<Value> of the ValueList for `k`.
@@ -260,22 +260,20 @@ impl Mapping {
     /// Returns an error if called for a key which is marked constant.
     #[inline]
     pub fn get_mut(&mut self, k: &Value) -> Result<Option<&mut Value>> {
-        if !self.const_keys.contains(k) {
-            Ok(self.map.get_mut(k))
-        } else {
-            Err(anyhow!("Key {k} is marked constant"))
+        if self.const_keys.contains(k) {
+            return Err(anyhow!("Key {k} is marked constant"));
         }
+        Ok(self.map.get_mut(k))
     }
 
     /// Returns the given key's entry in the map for insertion and/or in-place updates.
     /// Returns an error if called for a key which is marked constant.
     #[inline]
     pub fn entry(&mut self, k: Value) -> Result<indexmap::map::Entry<Value, Value>> {
-        if !self.const_keys.contains(&k) {
-            Ok(self.map.entry(k))
-        } else {
-            Err(anyhow!("Key {k} is marked constant"))
+        if self.const_keys.contains(&k) {
+            return Err(anyhow!("Key {k} is marked constant"));
         }
+        Ok(self.map.entry(k))
     }
 
     /// Removes the entry for key `k` from the map and returns its value if the key was present in

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -300,6 +300,7 @@ impl Mapping {
     }
 
     /// Checks if the map is empty
+    #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.map.len() == 0
@@ -319,12 +320,14 @@ impl Mapping {
     }
 
     /// Checks if the provided key is marked as constant.
+    #[inline]
     #[must_use]
     fn is_const(&self, k: &Value) -> bool {
         self.const_keys.contains(k)
     }
 
     /// Checks if the provided key is marked as overriding.
+    #[inline]
     #[must_use]
     fn is_override(&self, k: &Value) -> bool {
         self.override_keys.contains(k)

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -121,8 +121,13 @@ impl From<Value> for serde_json::Value {
                     return Self::String(n.to_string());
                 }
                 let jn = if n.is_i64() {
+                    // While the lint is enabled generally, we don't care if we lose some precision
+                    // here. If this turns out to be a real problem, we can enable serde_json's
+                    // arbitrary precision numbers feature.
+                    #[allow(clippy::cast_precision_loss)]
                     serde_json::Number::from_f64(n.as_i64().unwrap() as f64).unwrap()
                 } else if n.is_u64() {
+                    #[allow(clippy::cast_precision_loss)]
                     serde_json::Number::from_f64(n.as_u64().unwrap() as f64).unwrap()
                 } else if n.is_f64() {
                     serde_json::Number::from_f64(n.as_f64().unwrap()).unwrap()

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -425,12 +425,15 @@ impl Value {
     }
 
     /// Converts the `Value` into a `PyObject`.
+    #[allow(clippy::missing_panics_doc)]
     pub fn as_py_obj(&self, py: Python<'_>) -> PyResult<PyObject> {
         let obj = match self {
             Value::Literal(s) | Value::String(s) => s.into_py(py),
             Value::Bool(b) => b.into_py(py),
             Value::Number(n) => {
                 if n.is_i64() {
+                    // NOTE(sg): We allow the missing panics doc because we already checked that
+                    // `as_i64()` can't panic here.
                     n.as_i64().unwrap().into_py(py)
                 } else if n.is_u64() {
                     n.as_u64().unwrap().into_py(py)

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -463,20 +463,20 @@ impl Value {
     ///
     /// For non-String values, the value is unconditionally cloned and returned unmodified.
     #[inline]
-    pub(super) fn strip_prefix(&self) -> (Self, Option<KeyPrefix>) {
+    pub(super) fn strip_prefix(self) -> (Self, Option<KeyPrefix>) {
         match self {
             Self::String(s) => {
                 if s.is_empty() {
-                    return (self.clone(), None);
+                    return (Self::String(s), None);
                 }
                 let p = KeyPrefix::from(s.chars().next().unwrap());
                 if p.is_some() {
                     (Self::String(s[1..].to_string()), p)
                 } else {
-                    (self.clone(), None)
+                    (Self::String(s), None)
                 }
             }
-            _ => (self.clone(), None),
+            _ => (self, None),
         }
     }
 

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -349,9 +349,10 @@ impl Value {
             Self::Mapping(m) => m.get(k),
             Self::Sequence(s) | Self::ValueList(s) => {
                 if let Some(idx) = k.as_u64() {
-                    let idx = idx as usize;
-                    if idx < s.len() {
-                        return Some(&s[idx]);
+                    if let Ok(idx) = usize::try_from(idx) {
+                        if idx < s.len() {
+                            return Some(&s[idx]);
+                        }
                     }
                 }
                 None
@@ -375,7 +376,7 @@ impl Value {
             Self::Mapping(m) => m.get_mut(k),
             Self::Sequence(s) | Self::ValueList(s) => {
                 if let Some(idx) = k.as_u64() {
-                    let idx = idx as usize;
+                    let idx = usize::try_from(idx)?;
                     if idx < s.len() {
                         return Ok(Some(&mut s[idx]));
                     }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -93,11 +93,9 @@ impl Hash for Value {
             Self::Null => {}
             Self::Bool(v) => v.hash(state),
             Self::Number(v) => v.hash(state),
-            Self::String(v) => v.hash(state),
-            Self::Sequence(v) => v.hash(state),
+            Self::Literal(v) | Self::String(v) => v.hash(state),
             Self::Mapping(v) => v.hash(state),
-            Self::ValueList(v) => v.hash(state),
-            Self::Literal(v) => v.hash(state),
+            Self::Sequence(v) | Self::ValueList(v) => v.hash(state),
         }
     }
 }
@@ -136,8 +134,7 @@ impl From<Value> for serde_json::Value {
                 };
                 serde_json::Value::Number(jn)
             }
-            Value::String(s) => Self::String(s),
-            Value::Literal(s) => Self::String(s),
+            Value::Literal(s) | Value::String(s) => Self::String(s),
             Value::Sequence(s) => {
                 let mut seq: Vec<Self> = Vec::with_capacity(s.len());
                 for v in s {
@@ -274,8 +271,7 @@ impl Value {
     #[must_use]
     pub fn as_str(&self) -> Option<&str> {
         match self {
-            Self::String(s) => Some(s),
-            Self::Literal(s) => Some(s),
+            Self::Literal(s) | Self::String(s) => Some(s),
             _ => None,
         }
     }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -149,18 +149,21 @@ impl From<Value> for serde_json::Value {
 impl Value {
     /// Checks if the `Value` is `Null`.
     #[inline]
+    #[must_use]
     pub fn is_null(&self) -> bool {
         matches!(self, Self::Null)
     }
 
     /// Checks if the `Value` is a boolean.
     #[inline]
+    #[must_use]
     pub fn is_bool(&self) -> bool {
         matches!(self, Self::Bool(_))
     }
 
     /// If the `Value` is a Boolean, return the associated bool. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_bool(&self) -> Option<bool> {
         match self {
             Self::Bool(b) => Some(*b),
@@ -173,6 +176,7 @@ impl Value {
     /// For any value for which `is_i64` returns true, `as_i64` is guaranteed to return the
     /// integer value.
     #[inline]
+    #[must_use]
     pub fn is_i64(&self) -> bool {
         match self {
             Self::Number(n) => n.is_i64(),
@@ -182,6 +186,7 @@ impl Value {
 
     /// If the `Value` is an integer, represent it as i64 if possible. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_i64(&self) -> Option<i64> {
         match self {
             Self::Number(n) => n.as_i64(),
@@ -194,6 +199,7 @@ impl Value {
     /// For any value for which `is_u64` returns true, `as_u64` is guaranteed to return the
     /// integer value.
     #[inline]
+    #[must_use]
     pub fn is_u64(&self) -> bool {
         match self {
             Self::Number(n) => n.is_u64(),
@@ -203,6 +209,7 @@ impl Value {
 
     /// If the `Value` is an integer, represent it as u64 if possible. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_u64(&self) -> Option<u64> {
         match self {
             Self::Number(n) => n.as_u64(),
@@ -219,6 +226,7 @@ impl Value {
     /// returns true if and only if both `is_i64` and `is_u64` return false, but since serde_yaml
     /// doesn't guarantee this behavior in the future, this may change.
     #[inline]
+    #[must_use]
     pub fn is_f64(&self) -> bool {
         match self {
             Self::Number(n) => n.is_f64(),
@@ -228,6 +236,7 @@ impl Value {
 
     /// If the `Value` is a number, represent it as f64 if possible. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_f64(&self) -> Option<f64> {
         match self {
             Self::Number(n) => n.as_f64(),
@@ -240,6 +249,7 @@ impl Value {
     /// For any value for which `is_string()` returns true, `as_str` is guaranteed to return the
     /// string slice.
     #[inline]
+    #[must_use]
     pub fn is_string(&self) -> bool {
         matches!(self, Self::String(_))
     }
@@ -249,12 +259,14 @@ impl Value {
     /// For any value for which `is_literal()` returns true, `as_str` is guaranteed to return the
     /// string slice.
     #[inline]
+    #[must_use]
     pub fn is_literal(&self) -> bool {
         matches!(self, Self::Literal(_))
     }
 
     /// If the `Value` is a String or Literal, return the associated `str`. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_str(&self) -> Option<&str> {
         match self {
             Self::String(s) => Some(s),
@@ -265,12 +277,14 @@ impl Value {
 
     /// Checks if the `Value` is a Mapping.
     #[inline]
+    #[must_use]
     pub fn is_mapping(&self) -> bool {
         matches!(self, Self::Mapping(_))
     }
 
     /// If the value is a Mapping, return a reference to it. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_mapping(&self) -> Option<&Mapping> {
         match self {
             Self::Mapping(m) => Some(m),
@@ -280,6 +294,7 @@ impl Value {
 
     /// If the value is a Mapping, return a mutable reference to it. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_mapping_mut(&mut self) -> Option<&mut Mapping> {
         match self {
             Self::Mapping(m) => Some(m),
@@ -289,12 +304,14 @@ impl Value {
 
     /// Checks if the `Value` is a Sequence.
     #[inline]
+    #[must_use]
     pub fn is_sequence(&self) -> bool {
         matches!(self, Self::Sequence(_))
     }
 
     /// If the value is a Sequence, return a reference to it. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_sequence(&self) -> Option<&Sequence> {
         match self {
             Self::Sequence(s) => Some(s),
@@ -304,6 +321,7 @@ impl Value {
 
     /// If the value is a Sequence, return a mutable reference to it. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_sequence_mut(&mut self) -> Option<&mut Sequence> {
         match self {
             Self::Sequence(s) => Some(s),
@@ -313,12 +331,14 @@ impl Value {
 
     /// Checks if the `Value` is a ValueList.
     #[inline]
+    #[must_use]
     pub fn is_value_list(&self) -> bool {
         matches!(self, Self::ValueList(_))
     }
 
     /// If the value is a ValueList, return a reference to it. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_value_list(&self) -> Option<&Sequence> {
         match self {
             Self::ValueList(l) => Some(l),
@@ -328,6 +348,7 @@ impl Value {
 
     /// If the value is a ValueList, return a mutable reference to it. Returns None otherwise.
     #[inline]
+    #[must_use]
     pub fn as_value_list_mut(&mut self) -> Option<&mut Sequence> {
         match self {
             Self::ValueList(l) => Some(l),
@@ -344,6 +365,7 @@ impl Value {
     ///
     /// Returns None for invalid keys, or keys which don't exist in the `Value`.
     #[inline]
+    #[must_use]
     pub fn get(&self, k: &Value) -> Option<&Value> {
         match self {
             Self::Mapping(m) => m.get(k),

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -418,7 +418,7 @@ impl Value {
             }
             Value::Sequence(s) => {
                 let mut pyseq = vec![];
-                for v in s.iter() {
+                for v in s {
                     pyseq.push(v.as_py_obj(py)?);
                 }
                 pyseq.into_py(py)
@@ -520,7 +520,7 @@ impl Value {
             Self::Sequence(s) => {
                 // Sequences are interpolated by calling interpolate() for each element.
                 let mut seq = vec![];
-                for it in s.iter() {
+                for it in s {
                     let e = it.interpolate(root)?;
                     seq.push(e);
                 }
@@ -630,7 +630,7 @@ impl Value {
             Self::ValueList(l) => {
                 // NOTE(sg): Empty ValueLists get flattened to Value::Null
                 let mut base = Value::Null;
-                for v in l.iter() {
+                for v in l {
                     base.merge(v.clone())?;
                 }
                 Ok(base)
@@ -638,7 +638,7 @@ impl Value {
             // Flatten Mapping by flattening each value and inserting it into a new Mapping.
             Self::Mapping(m) => {
                 let mut n = Mapping::new();
-                for (k, v) in m.iter() {
+                for (k, v) in m {
                     n.insert(k.clone(), v.flattened()?)?;
                 }
                 Ok(Self::Mapping(n))


### PR DESCRIPTION
We currently allow the following lints which are included in `clippy::pedantic`:

* `clippy::doc_markdown`
* `clippy::missing_errors_doc`
* `clippy::module_name_repetitions`
* `clippy::similar_names`

See indvidiual commits for the lints which are fixed in this PR.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
