### PR TITLE
Implement `Reclass::inventory()` and associated `Inventory` type 

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,0 +1,130 @@
+use anyhow::{anyhow, Result};
+use chrono::Local;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use std::collections::HashMap;
+
+use super::{NodeInfo, Reclass};
+
+#[pyclass]
+#[derive(Debug, Default)]
+pub struct Inventory {
+    /// Maps each application which is included by at least one node to the list of nodes which
+    /// include it.
+    #[pyo3(get)]
+    applications: HashMap<String, Vec<String>>,
+    /// Maps each class which is included by at least one node to the list of nodes which include
+    /// it.
+    #[pyo3(get)]
+    classes: HashMap<String, Vec<String>>,
+    /// Maps each node name discovered by `Reclass::discover_nodes()` to its `NodeInfo`.
+    #[pyo3(get)]
+    nodes: HashMap<String, NodeInfo>,
+}
+
+impl Inventory {
+    /// Renders the full inventory for the given Reclass config.
+    pub fn render(r: &Reclass) -> Result<Self> {
+        // Render all nodes
+        let infos: Vec<_> = r
+            .nodes
+            .keys()
+            .map(|name| (name, { r.render_node(name) }))
+            .collect();
+
+        // Generate `Inventory` from the rendered nodes
+        let mut inv = Self::default();
+        for (name, info) in infos {
+            let info = info.map_err(|e| anyhow!("Error rendering node {name}: {e}"))?;
+            for cls in &info.classes {
+                inv.classes
+                    .entry(cls.clone())
+                    .and_modify(|nodes: &mut Vec<String>| nodes.push(name.clone()))
+                    .or_insert(vec![name.clone()]);
+            }
+            for app in &info.applications {
+                inv.applications
+                    .entry(app.clone())
+                    .and_modify(|nodes: &mut Vec<String>| nodes.push(name.clone()))
+                    .or_insert(vec![name.clone()]);
+            }
+            inv.nodes.insert(name.clone(), info);
+        }
+        Ok(inv)
+    }
+}
+
+#[pymethods]
+impl Inventory {
+    /// Returns the Inventory as a Python dict.
+    ///
+    /// The structure of the returned dict should match Python reclass the structure of the dict
+    /// returned by Python reclass's `inventory()` method.
+    fn as_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let dict = PyDict::new(py);
+        dict.set_item("applications", self.applications.clone().into_py(py))?;
+        dict.set_item("classes", self.classes.clone().into_py(py))?;
+        let nodes_dict = PyDict::new(py);
+        for (name, info) in &self.nodes {
+            nodes_dict.set_item(name, info.as_dict(py)?)?;
+        }
+        dict.set_item("nodes", nodes_dict)?;
+
+        let reclass_dict = PyDict::new(py);
+        let ts = Local::now();
+        reclass_dict.set_item("timestamp", ts.format("%c").to_string())?;
+        dict.set_item("__reclass__", reclass_dict)?;
+        Ok(dict.into())
+    }
+}
+
+#[cfg(test)]
+mod inventory_tests {
+    use super::*;
+
+    #[test]
+    fn test_render() {
+        let r = Reclass::new(
+            "./tests/inventory/nodes",
+            "./tests/inventory/classes",
+            false,
+        )
+        .unwrap();
+        let inv = Inventory::render(&r).unwrap();
+
+        // Check that all nodes are in `inv.nodes`. We do not verify the NodeInfos here, since we
+        // have individual tests for each NodeInfo in `src/node`.
+        let mut nodes = inv.nodes.keys().cloned().collect::<Vec<String>>();
+        nodes.sort();
+        assert_eq!(
+            nodes,
+            (1..=4).map(|n| format!("n{n}")).collect::<Vec<String>>()
+        );
+
+        // applications should contain app[1-2]
+        let mut expected_applications = HashMap::<String, Vec<String>>::new();
+        expected_applications.insert("app1".into(), vec!["n1".into()]);
+        expected_applications.insert("app2".into(), vec!["n1".into()]);
+        assert_eq!(inv.applications, expected_applications);
+
+        // classes should contain:
+        // * cls[1-8]
+        // * ${qux} -- interpolated as cls1 for n4, but both Python reclass and our implementation
+        // have the uninterpolated class name in the classes list.
+        // * nested.cls[1-2]
+        let mut expected_classes = HashMap::<String, Vec<String>>::new();
+        expected_classes.insert("cls1".into(), vec!["n1".into()]);
+        expected_classes.insert("cls2".into(), vec!["n1".into()]);
+        expected_classes.insert("nested.cls1".into(), vec!["n2".into()]);
+        expected_classes.insert("nested.cls2".into(), vec!["n2".into()]);
+        expected_classes.insert("cls3".into(), vec!["n3".into()]);
+        expected_classes.insert("cls4".into(), vec!["n3".into()]);
+        expected_classes.insert("cls5".into(), vec!["n3".into()]);
+        expected_classes.insert("cls6".into(), vec!["n3".into()]);
+        expected_classes.insert("cls7".into(), vec!["n4".into()]);
+        expected_classes.insert("cls8".into(), vec!["n4".into()]);
+        expected_classes.insert("${qux}".into(), vec!["n4".into()]);
+
+        assert_eq!(inv.classes, expected_classes);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use walkdir::WalkDir;
 
-use crate::node::{Node, NodeInfo, NodeInfoMeta};
+use node::{Node, NodeInfo, NodeInfoMeta};
 
 const SUPPORTED_YAML_EXTS: [&str; 2] = ["yml", "yaml"];
 
@@ -36,64 +36,89 @@ pub struct Reclass {
     /// Whether to ignore included classes which don't exist (yet)
     #[pyo3(get)]
     pub ignore_class_notfound: bool,
+    /// List of discovered Reclass classes in `classes_path`
     classes: HashMap<String, PathBuf>,
+    /// List of discovered Reclass nodes in `nodes_path`
+    nodes: HashMap<String, PathBuf>,
+}
+
+fn err_duplicate_entity(root: &str, relpath: &Path, cls: &str, prev: &Path) -> Result<()> {
+    fn stringify(p: &Path) -> Result<&str> {
+        p.to_str()
+            .ok_or(anyhow!("Failed to convert {} to string", p.display()))
+    }
+    // Reconstruct absolute entity paths for the error message
+    let mut previnv = PathBuf::from(root);
+    previnv.push(prev);
+    let prev = stringify(&previnv)?;
+    let mut pathinv = PathBuf::from(root);
+    pathinv.push(relpath);
+    let relpath = stringify(&pathinv)?;
+    // Ensure error message is stable without having to sort the directory walk
+    // iterator.
+    let (first, second) = if prev.cmp(relpath).is_lt() {
+        (prev, relpath)
+    } else {
+        (relpath, prev)
+    };
+    Err(anyhow!(
+        "Definition of class '{cls}' in '{first}' collides with definition in '{second}'. \
+            Classes can only be defined once per inventory."
+    ))
+}
+
+fn walk_entity_dir(
+    root: &str,
+    entity_map: &mut HashMap<String, PathBuf>,
+    max_depth: usize,
+) -> Result<()> {
+    let entity_root = PathBuf::from(root).canonicalize()?;
+
+    for entry in WalkDir::new(root).max_depth(max_depth) {
+        let entry = entry?;
+        let ext = if let Some(ext) = entry.path().extension() {
+            ext.to_str()
+        } else {
+            None
+        };
+        if ext.is_some() && SUPPORTED_YAML_EXTS.contains(&ext.unwrap()) {
+            // it's an entity (class or node), process it
+            let abspath = entry.path().canonicalize()?;
+            let relpath = abspath.strip_prefix(&entity_root)?;
+            let cls = relpath
+                .with_extension("")
+                .to_str()
+                .ok_or(anyhow!(
+                    "Failed to canonicalize entity {}",
+                    entry.path().display()
+                ))?
+                .replace(MAIN_SEPARATOR, ".");
+            if let Some(prev) = entity_map.get(&cls) {
+                return err_duplicate_entity(root, relpath, &cls, prev);
+            }
+            entity_map.insert(cls, relpath.to_path_buf());
+        }
+    }
+    Ok(())
 }
 
 impl Reclass {
+    /// Discover all top-level YAML files in `r.nodes_path`.
+    ///
+    /// This method will raise an error if multiple nodes which resolve to the same node name
+    /// exist. Currently the only case where this can happen is when an inventory defines a node as
+    /// both `<name>.yml` and `<name>.yaml`.
+    fn discover_nodes(&mut self) -> Result<()> {
+        walk_entity_dir(&self.nodes_path, &mut self.nodes, 1)
+    }
+
     /// Discover all classes in `r.classes_path` and store the resulting list in `r.known_classes`.
     ///
     /// This method will raise an error if multiple classes which resolve to the same absolute
     /// class name exist (e.g. classes `foo..bar.yml` and `foo/.bar.yml` are both included as
     /// `foo..bar`).
     fn discover_classes(&mut self) -> Result<()> {
-        fn stringify(p: &Path) -> Result<&str> {
-            p.to_str()
-                .ok_or(anyhow!("Failed to convert {} to string", p.display()))
-        }
-        let class_root = PathBuf::from(&self.classes_path).canonicalize()?;
-
-        for entry in WalkDir::new(&self.classes_path) {
-            let entry = entry?;
-            let ext = if let Some(ext) = entry.path().extension() {
-                ext.to_str()
-            } else {
-                None
-            };
-            if ext.is_some() && SUPPORTED_YAML_EXTS.contains(&ext.unwrap()) {
-                // it's a class, process it
-                let abspath = entry.path().canonicalize()?;
-                let relpath = abspath.strip_prefix(&class_root)?;
-                let cls = relpath
-                    .with_extension("")
-                    .to_str()
-                    .ok_or(anyhow!(
-                        "Failed to canonicalize class {}",
-                        entry.path().display()
-                    ))?
-                    .replace(MAIN_SEPARATOR, ".");
-                if let Some(prev) = self.classes.get(&cls) {
-                    let mut previnv = PathBuf::from(&self.classes_path);
-                    previnv.push(prev);
-                    let prev = stringify(&previnv)?;
-                    let mut pathinv = PathBuf::from(&self.classes_path);
-                    pathinv.push(relpath);
-                    let relpath = stringify(&pathinv)?;
-                    // Ensure error message is stable without having to sort the directory walk
-                    // iterator.
-                    let (first, second) = if prev.cmp(relpath).is_lt() {
-                        (prev, relpath)
-                    } else {
-                        (relpath, prev)
-                    };
-                    return Err(anyhow!(
-                        "Definition of class '{cls}' in '{first}' collides with definition in '{second}'. \
-                        Classes can only be defined once per inventory."
-                    ));
-                }
-                self.classes.insert(cls, relpath.to_path_buf());
-            }
-        }
-        Ok(())
+        walk_entity_dir(&self.classes_path, &mut self.classes, usize::MAX)
     }
 
     /// Renders a single Node and returns the corresponding `NodeInfo` struct.
@@ -118,7 +143,10 @@ impl Reclass {
             classes_path: classes_path.to_owned(),
             ignore_class_notfound,
             classes: HashMap::new(),
+            nodes: HashMap::new(),
         };
+        r.discover_nodes()
+            .map_err(|e| PyValueError::new_err(format!("Error while discovering nodes: {e}")))?;
         r.discover_classes()
             .map_err(|e| PyValueError::new_err(format!("Error while discovering classes: {e}")))?;
         Ok(r)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,13 @@ impl Reclass {
         }
         Ok(())
     }
+
+    /// Renders a single Node and returns the corresponding `NodeInfo` struct.
+    fn render_node(&self, nodename: &str) -> Result<NodeInfo> {
+        let mut n = Node::parse(self, nodename)?;
+        n.render(self)?;
+        Ok(NodeInfo::from(n))
+    }
 }
 
 #[pymethods]
@@ -121,14 +128,10 @@ impl Reclass {
         format!("{self:#?}")
     }
 
-    /// Returns the rendered data for the node with the provided name if it exists
+    /// Returns the rendered data for the node with the provided name if it exists.
     pub fn nodeinfo(&self, nodename: &str) -> PyResult<NodeInfo> {
-        let mut n = Node::parse(self, nodename)
-            .map_err(|e| PyValueError::new_err(format!("Error while parsing {nodename}: {e}")))?;
-        n.render(self)
-            .map_err(|e| PyValueError::new_err(format!("Error while rendering {nodename}: {e}")))?;
-
-        Ok(n.into())
+        self.render_node(nodename)
+            .map_err(|e| PyValueError::new_err(format!("Error while rendering {nodename}: {e}")))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::similar_names)]
 
+mod inventory;
 mod list;
 mod node;
 mod refs;
@@ -19,6 +20,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use walkdir::WalkDir;
 
+use inventory::Inventory;
 use node::{Node, NodeInfo, NodeInfoMeta};
 
 const SUPPORTED_YAML_EXTS: [&str; 2] = ["yml", "yaml"];
@@ -161,6 +163,12 @@ impl Reclass {
         self.render_node(nodename)
             .map_err(|e| PyValueError::new_err(format!("Error while rendering {nodename}: {e}")))
     }
+
+    /// Returns the rendered data for the full inventory.
+    pub fn inventory(&self) -> PyResult<Inventory> {
+        Inventory::render(self)
+            .map_err(|e| PyValueError::new_err(format!("Error while rendering inventory: {e}")))
+    }
 }
 
 impl Default for Reclass {
@@ -176,6 +184,8 @@ fn reclass_rs(_py: Python, m: &PyModule) -> PyResult<()> {
     // Register the NodeInfoMeta and NodeInfo classes
     m.add_class::<NodeInfoMeta>()?;
     m.add_class::<NodeInfo>()?;
+    // Register the Inventory class
+    m.add_class::<Inventory>()?;
     Ok(())
 }
 

--- a/src/node/nodeinfo.rs
+++ b/src/node/nodeinfo.rs
@@ -133,7 +133,7 @@ impl NodeInfo {
     ///
     /// This method generates a PyDict which should be structured identically to Python Reclass's
     /// `nodeinfo` return value.
-    fn as_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+    pub(crate) fn as_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
         let dict = PyDict::new(py);
         dict.set_item("__reclass__", self.reclass_as_dict(py)?)?;
         dict.set_item("applications", self.applications.clone().into_py(py))?;

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -17,4 +17,4 @@ def test_import_raises():
     with pytest.raises(ValueError) as exc:
         r = reclass_rs.Reclass("./foo", "./bar")
 
-    assert "Error while discovering classes" in str(exc.value)
+    assert "Error while discovering nodes" in str(exc.value)

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,68 @@
+import reclass_rs
+
+
+def test_inventory():
+    r = reclass_rs.Reclass(
+        nodes_path="./tests/inventory/nodes", classes_path="./tests/inventory/classes"
+    )
+    inv = r.inventory()
+
+    assert set(inv.nodes.keys()) == set(["n1", "n2", "n3", "n4"])
+
+    expected_classes = {
+        "cls1": ["n1"],
+        "cls2": ["n1"],
+        "cls3": ["n3"],
+        "cls4": ["n3"],
+        "cls5": ["n3"],
+        "cls6": ["n3"],
+        "cls7": ["n4"],
+        "cls8": ["n4"],
+        "${qux}": ["n4"],
+        "nested.cls1": ["n2"],
+        "nested.cls2": ["n2"],
+    }
+
+    assert inv.classes == expected_classes
+
+    expected_applications = {
+        "app1": ["n1"],
+        "app2": ["n1"],
+    }
+
+    assert inv.applications == expected_applications
+
+
+def test_inventory_as_dict():
+    r = reclass_rs.Reclass(
+        nodes_path="./tests/inventory/nodes", classes_path="./tests/inventory/classes"
+    )
+    inv = r.inventory().as_dict()
+
+    assert set(inv["nodes"].keys()) == set(["n1", "n2", "n3", "n4"])
+
+    expected_classes = {
+        "cls1": ["n1"],
+        "cls2": ["n1"],
+        "cls3": ["n3"],
+        "cls4": ["n3"],
+        "cls5": ["n3"],
+        "cls6": ["n3"],
+        "cls7": ["n4"],
+        "cls8": ["n4"],
+        "${qux}": ["n4"],
+        "nested.cls1": ["n2"],
+        "nested.cls2": ["n2"],
+    }
+
+    assert inv["classes"] == expected_classes
+
+    expected_applications = {
+        "app1": ["n1"],
+        "app2": ["n1"],
+    }
+
+    assert inv["applications"] == expected_applications
+
+    assert "__reclass__" in inv
+    assert set(inv["__reclass__"].keys()) == set(["timestamp"])

--- a/tests/test_nodeinfo.py
+++ b/tests/test_nodeinfo.py
@@ -1,11 +1,21 @@
 import reclass_rs
 
+import platform
+from pathlib import Path
+
 
 def test_nodeinfo_n1():
     r = reclass_rs.Reclass(
         nodes_path="./tests/inventory/nodes", classes_path="./tests/inventory/classes"
     )
     n = r.nodeinfo("n1")
+    npath = Path("./tests/inventory/nodes/n1.yml").resolve()
+    unc_infix = ""
+    if platform.system() == "Windows":
+        # On Windows, Rust's std::fs::canonicalize uses UNC paths, so the path is prefixed with
+        # `\\?\`. Python's pathlib doesn't do that when resolving paths.
+        unc_infix = "\\\\?\\"
+    assert n.__reclass__.uri == f"yaml_fs://{unc_infix}{npath}"
     assert n.applications == ["app1", "app2"]
     assert n.classes == ["cls1", "cls2"]
     assert n.parameters == {


### PR DESCRIPTION
This PR implements a Python method `Reclass::inventory()` and an associated Rust method `Inventory::render()` which discovers all existing nodes in the given nodes path and renders all of them.

The PR also adds a Python method `Inventory::as_dict()` which transforms an Inventory object into a dict which should have the same structure as the dict which is returned by Python reclass's `inventory()` method.

Additionally, we implement `Reclass::discover_nodes()` based on the existing implementation for `Reclass::discover_classes()` and refactor `Node::parse()` to use the cached information about existing nodes when loading a node's YAML from disk. 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
