### PR TITLE
Add empty `exports` field in `NodeInfo`

### DIFF
--- a/src/node/nodeinfo.rs
+++ b/src/node/nodeinfo.rs
@@ -85,6 +85,7 @@ pub struct NodeInfo {
     pub applications: Vec<String>,
     #[pyo3(get)]
     pub classes: Vec<String>,
+    pub exports: Mapping,
     pub parameters: Mapping,
 }
 
@@ -96,6 +97,8 @@ impl From<super::Node> for NodeInfo {
             applications: n.applications.into(),
             classes: n.classes.into(),
             parameters: n.parameters,
+            // NOTE(sg): Python reclass's exports functionality is not implemented yet.
+            exports: Mapping::new(),
         }
     }
 }
@@ -112,6 +115,14 @@ impl NodeInfo {
         self.parameters.as_py_dict(py)
     }
 
+    /// Returns the NodeInfo `exports` field as a PyDict
+    #[getter]
+    fn exports(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        #[cfg(debug_assertions)]
+        eprintln!("reclass_rs doesn't support exports yet!");
+        self.exports.as_py_dict(py)
+    }
+
     /// Returns the NodeInfo data as a PyDict
     ///
     /// This method generates a PyDict which should be structured identically to Python Reclass's
@@ -122,6 +133,7 @@ impl NodeInfo {
         dict.set_item("applications", self.applications.clone().into_py(py))?;
         dict.set_item("classes", self.classes.clone().into_py(py))?;
         dict.set_item("environment", self.reclass.environment.clone().into_py(py))?;
+        dict.set_item("exports", self.exports(py)?)?;
         dict.set_item("parameters", self.parameters(py)?)?;
         Ok(dict.into())
     }

--- a/src/node/nodeinfo.rs
+++ b/src/node/nodeinfo.rs
@@ -79,13 +79,19 @@ impl NodeInfoMeta {
 #[pyclass]
 #[derive(Clone, Debug)]
 pub struct NodeInfo {
+    /// Reclass metadata for the node.
     #[pyo3(get, name = "__reclass__")]
     pub reclass: NodeInfoMeta,
+    /// Applications included by the node.
     #[pyo3(get)]
     pub applications: Vec<String>,
+    /// Classes included by the node.
     #[pyo3(get)]
     pub classes: Vec<String>,
+    /// Exports defined for the node.
+    /// Note that the exports functionality is not yet implemented.
     pub exports: Mapping,
+    /// Parameters defined for the node.
     pub parameters: Mapping,
 }
 


### PR DESCRIPTION
We add this to bring the output of reclass_rs closer to Python reclass. In debug builds a warning is printed that `exports` aren't supported yet.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
