### PR TITLE
Handle symlinks in `nodes_path` or `classes_path` as separate entities

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -8,7 +8,7 @@ use yaml_merge_keys::merge_keys_serde;
 use crate::list::{List, RemovableList, UniqueList};
 use crate::refs::Token;
 use crate::types::{Mapping, Value};
-use crate::Reclass;
+use crate::{to_lexical_absolute, Reclass};
 
 mod nodeinfo;
 
@@ -49,7 +49,7 @@ impl Node {
         invpath.push(npath);
         let ncontents = std::fs::read_to_string(invpath.canonicalize()?)?;
 
-        meta.uri = format!("yaml_fs://{}", invpath.canonicalize()?.display());
+        meta.uri = format!("yaml_fs://{}", to_lexical_absolute(&invpath)?.display());
 
         Node::from_str(meta, None, &ncontents)
     }

--- a/tests/inventory/classes/config_symlink.yml
+++ b/tests/inventory/classes/config_symlink.yml
@@ -1,0 +1,1 @@
+config.yml

--- a/tests/test_nodeinfo.py
+++ b/tests/test_nodeinfo.py
@@ -27,6 +27,15 @@ def test_nodeinfo_n1():
     }
 
 
+def test_nodeinfo_n1_meta_symlink():
+    r = reclass_rs.Reclass(
+        nodes_path="./tests/inventory/targets", classes_path="./tests/inventory/classes"
+    )
+    n = r.nodeinfo("n1")
+    npath = Path("./tests/inventory/targets/n1.yml").absolute()
+    assert n.__reclass__.uri == f"yaml_fs://{npath}"
+
+
 def test_nodeinfo_n2():
     r = reclass_rs.Reclass(
         nodes_path="./tests/inventory/nodes", classes_path="./tests/inventory/classes"

--- a/tests/test_nodeinfo.py
+++ b/tests/test_nodeinfo.py
@@ -1,6 +1,5 @@
 import reclass_rs
 
-import platform
 from pathlib import Path
 
 
@@ -10,12 +9,7 @@ def test_nodeinfo_n1():
     )
     n = r.nodeinfo("n1")
     npath = Path("./tests/inventory/nodes/n1.yml").resolve()
-    unc_infix = ""
-    if platform.system() == "Windows":
-        # On Windows, Rust's std::fs::canonicalize uses UNC paths, so the path is prefixed with
-        # `\\?\`. Python's pathlib doesn't do that when resolving paths.
-        unc_infix = "\\\\?\\"
-    assert n.__reclass__.uri == f"yaml_fs://{unc_infix}{npath}"
+    assert n.__reclass__.uri == f"yaml_fs://{npath}"
     assert n.applications == ["app1", "app2"]
     assert n.classes == ["cls1", "cls2"]
     assert n.parameters == {


### PR DESCRIPTION
We introduce function `to_lexical_absolute()` which converts a Path into its normalized absolute form without resolving symlinks. We replace our usage of `canonicalize()` with that function, so that we correctly treat symlinks in `nodes_path` or `classes_path` as separate entities (nodes or classes).

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
