### PR TITLE
Parallelize inventory rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4.30"
 indexmap = "2.0.0"
 nom = "7.1.3"
 pyo3 = { version = "0.19.2", features = ["chrono"] }
+rayon = "1.7.0"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.106"
 serde_yaml = "0.9.25"

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use chrono::Local;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use rayon::prelude::*;
 use std::collections::HashMap;
 
 use super::{NodeInfo, Reclass};
@@ -28,8 +29,8 @@ impl Inventory {
         // Render all nodes
         let infos: Vec<_> = r
             .nodes
-            .keys()
-            .map(|name| (name, { r.render_node(name) }))
+            .par_iter()
+            .map(|(name, _)| (name, { r.render_node(name) }))
             .collect();
 
         // Generate `Inventory` from the rendered nodes


### PR DESCRIPTION
We add `rayon` as a dependency and adjust the inventory rendering logic to use `par_iter()` to render nodeinfos in parallel.

Additionally, the PR introduces a Python classmethod `Reclass.set_thread_count()` which allows users to control how many threads are spawned for the Rayon default threadpool. If that method is called mutliple times, any calls except the first one will do nothing and print a diagnostic message.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
