### PR TITLE
Follow symlinks when discovering nodes or classes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,11 @@ fn walk_entity_dir(
 ) -> Result<()> {
     let entity_root = to_lexical_absolute(&PathBuf::from(root))?;
 
-    for entry in WalkDir::new(root).max_depth(max_depth) {
+    // We need to follow symlinks when walking the root directory, so that inventories which
+    // contain symlinked directories are loaded correctly.
+    for entry in WalkDir::new(root).max_depth(max_depth).follow_links(true) {
         let entry = entry?;
+        // We use `entry.path()` here to get the symlink name for symlinked files.
         let ext = if let Some(ext) = entry.path().extension() {
             ext.to_str()
         } else {


### PR DESCRIPTION
We need to follow symlinks when discovering nodes or classes, so that all classes and nodes in inventories which use symlinks to include additional directories in the inventory (e.g. Commodore's config package mechanism) are discovered.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
