### PR TITLE
Add check for matching package version and tag in release GitHub actions 

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -144,9 +144,26 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/v')"
     needs: [linux, windows, macos, sdist]
     steps:
+      - uses: actions/checkout@v4
+      - name: Extract Git version from ref
+        id: git_version
+        run: echo "version=$(echo ${GITHUB_REF#refs/tags/})" >> ${GITHUB_OUTPUT}
+        env:
+          GITHUB_REF: ${{ github.ref }}
+      - name: Read Cargo.toml
+        id: cargo_version
+        uses: SebRollen/toml-action@v1.0.2
+        with:
+          file: Cargo.toml
+          field: package.version
+      - name: Verify that tag matches Cargo.toml version
+        run: |
+          if [ "v${{ steps.cargo_version.outputs.value }}" != "${{ steps.git_version.outputs.version }}" ]; then
+            exit 1
+          fi
       - uses: actions/download-artifact@v3
         with:
           name: wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,26 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
+      - uses: actions/checkout@v4
+      - name: Extract Git version from ref
+        id: git_version
+        run: echo "version=$(echo ${GITHUB_REF#refs/tags/})" >> ${GITHUB_OUTPUT}
+        env:
+          GITHUB_REF: ${{ github.ref }}
+      - name: Read Cargo.toml
+        id: cargo_version
+        uses: SebRollen/toml-action@v1.0.2
+        with:
+          file: Cargo.toml
+          field: package.version
+      - name: Verify that tag matches Cargo.toml version
+        run: |
+          if [ "v${{ steps.cargo_version.outputs.value }}" != "${{ steps.git_version.outputs.version }}" ]; then
+            exit 1
+          fi
       - name: Build changelog from PRs with labels
-        if: startsWith(github.ref, 'refs/tags/v')
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4
         with:
@@ -22,7 +39,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Read release message from tag commit
         id: tag_message
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           git fetch origin +refs/tags/*:refs/tags/*
           # Extract tag message
@@ -40,7 +56,6 @@ jobs:
         env:
           GITHUB_REF: ${{ github.ref }}
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: ncipollo/release-action@v1
         with:
           body: "# Summary\n\n${{steps.tag_message.outputs.message}}\n\n# Changes\n\n${{steps.build_changelog.outputs.changelog}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reclass-rs"
-version = "0.1.0"
+version = "0.1.0-rc1"
 edition = "2021"
 license = "BSD-3-Clause"
 keywords = ["yaml", "reclass", "hierarchical config"]


### PR DESCRIPTION
Cancel the release jobs if the pushed tag doesn't match the current package version in `Cargo.toml`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
