### PR TITLE
Fix GitHub release actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -141,8 +141,8 @@ jobs:
           name: wheels
           path: dist
 
-  release:
-    name: Release
+  check-version:
+    name: Check if tag matches Cargo.toml version
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/v')"
     needs: [linux, windows, macos, sdist]
@@ -164,6 +164,13 @@ jobs:
           if [ "v${{ steps.cargo_version.outputs.value }}" != "${{ steps.git_version.outputs.version }}" ]; then
             exit 1
           fi
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/v')"
+    needs: [check-version]
+    steps:
       - uses: actions/download-artifact@v3
         with:
           name: wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,6 @@ jobs:
         with:
           body: "# Summary\n\n${{steps.tag_message.outputs.message}}\n\n# Changes\n\n${{steps.build_changelog.outputs.changelog}}"
           prerelease: "${{ contains(github.ref, '-rc') }}"
-          # Ensure target branch for release is "master"
-          commit: master
+          # Ensure target branch for release is "main"
+          commit: main
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Fix GitHub release job to target `main` branch
* Split Cargo.toml version check and maturin publish into separate jobs, since maturin tries to upload the `.git` directory otherwise.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
