### PR TITLE
Add support for escaped inventory query opening symbol

### DIFF
--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -48,7 +48,7 @@ impl Token {
     /// Parses an arbitrary string into a `Token`. Returns None, if the string doesn't contain any
     /// opening reference markers.
     pub fn parse(s: &str) -> Result<Option<Self>> {
-        if !s.contains("${") {
+        if !s.contains("${") && !s.contains("$[") {
             // return None for strings which don't contain any references
             return Ok(None);
         }


### PR DESCRIPTION
Kapitan's fork of Python Reclass supports a second query type which is called "inventory queries", cf.
https://github.com/kapicorp/reclass/blob/develop/README-extensions.rst#inventory-queries.

While we don't support inventory queries yet, this commit extends the reference parser to parse escaped inventory query opening symbols (`\$[`) the same way as the Python parser, by stripping the `\` and producing a literal `$[` token. This ensures that escaped inventory queries are parsed correctly by our parser.

Note that our parser doesn't actually parse inventory queries apart from escaped opening symbols. It still just produces a literal token for unescaped inventory queries.  Additionally, a double-escaped inventory query is parsed as `\` followed by an escaped opening symbol, resulting in a literal token `\$[` in the output.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
