### PR TITLE
Fix propagation of constant and overriding keys in Mapping interpolation and flattening

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -114,7 +114,7 @@ mod inventory_tests {
         let mut nodes = inv.nodes.keys().cloned().collect::<Vec<String>>();
         nodes.sort();
 
-        let mut expected_nodes = (1..=23).map(|n| format!("n{n}")).collect::<Vec<String>>();
+        let mut expected_nodes = (1..=24).map(|n| format!("n{n}")).collect::<Vec<String>>();
         expected_nodes.sort();
 
         assert_eq!(nodes, expected_nodes);
@@ -181,13 +181,16 @@ mod inventory_tests {
         expected_classes.insert("cluster.facts".into(), vec!["n19".into()]);
         expected_classes.insert("cluster.global".into(), vec!["n19".into()]);
         expected_classes.insert("config".into(), vec!["n16".into()]);
+        expected_classes.insert("defaults".into(), vec!["n24".into()]);
         expected_classes.insert("foo-indirect".into(), vec!["n20".into()]);
+        expected_classes.insert("meta".into(), vec!["n24".into()]);
         expected_classes.insert("nested.a".into(), vec!["n8".into()]);
         expected_classes.insert("nested.a_sub".into(), vec!["n8".into(), "n9".into()]);
         expected_classes.insert("nested.b".into(), vec!["n10".into()]);
         expected_classes.insert("nested.cls1".into(), vec!["n2".into()]);
         expected_classes.insert("nested.cls2".into(), vec!["n2".into()]);
         expected_classes.insert("nonexisting".into(), vec!["n18".into()]);
+        expected_classes.insert("override".into(), vec!["n24".into()]);
         expected_classes.insert("yaml-anchor".into(), vec!["n21".into()]);
 
         assert_eq!(inv.classes, expected_classes);

--- a/src/node/node_render_tests.rs
+++ b/src/node/node_render_tests.rs
@@ -591,7 +591,22 @@ fn test_render_n23() {
           qux: qux
         "#,
     );
-    dbg!(&n.parameters);
-    dbg!(&expected);
+    assert_eq!(n.parameters, expected);
+}
+
+#[test]
+fn test_render_n24() {
+    let r = make_reclass();
+    let n = r.render_node("n24").unwrap();
+
+    let expected = expected_params(
+        "n24",
+        r#"
+        fluentbit:
+          config:
+            inputs:
+              systemd: {}
+        "#,
+    );
     assert_eq!(n.parameters, expected);
 }

--- a/src/node/node_render_tests.rs
+++ b/src/node/node_render_tests.rs
@@ -143,7 +143,7 @@ fn test_render_n5() {
         r#"
     # from cls9
     foo: bar
-    constant: foo
+    =constant: foo
     foolist:
       - a
       - b
@@ -169,7 +169,7 @@ fn test_render_n6() {
         r#"
     # from cls9
     foo: baz
-    constant: foo
+    =constant: foo
     foolist:
       - a
       - b
@@ -201,7 +201,7 @@ fn test_render_n7() {
         r#"
         # from cls9
         foo: foo
-        constant: foo
+        =constant: foo
         # overwritten in n7
         foolist:
           - bar
@@ -255,7 +255,7 @@ fn test_render_n9() {
         r#"
         # from cls9 via cls13
         foo: foo
-        constant: foo
+        =constant: foo
         foolist:
           - a
           - b
@@ -286,7 +286,7 @@ fn test_render_n10() {
         r#"
     # from cls9 via nested.b
     foo: foo
-    constant: foo
+    =constant: foo
     foolist:
       - a
       - b
@@ -328,7 +328,7 @@ fn test_render_n12() {
         "n12",
         r#"
         foo: foo
-        constant: foo
+        =constant: foo
         foolist:
           - a
           - b
@@ -358,7 +358,7 @@ fn test_render_n13() {
         "n13",
         r#"
         foo: foo
-        constant: foo
+        =constant: foo
         foolist:
           - a
           - b
@@ -394,7 +394,7 @@ fn test_render_n14() {
         "n14",
         r#"
         foo: foo
-        constant: foo
+        =constant: foo
         foolist: [a, b, c]
         foodict:
           bar: bar
@@ -420,7 +420,7 @@ fn test_render_n15() {
         r#"
         cls9: cls9
         foo: foo
-        constant: foo
+        =constant: foo
         foolist:
           - a
           - b
@@ -470,7 +470,7 @@ fn test_render_n18() {
         "n18",
         r#"
     foo: foo
-    constant: foo
+    =constant: foo
     foolist:
       - a
       - b
@@ -581,7 +581,7 @@ fn test_render_n23() {
     let expected = expected_params(
         "n23",
         r#"
-        baz:
+        ~baz:
           baz: cls7
           foo: cls7
           qux: n19
@@ -591,5 +591,7 @@ fn test_render_n23() {
           qux: qux
         "#,
     );
+    dbg!(&n.parameters);
+    dbg!(&expected);
     assert_eq!(n.parameters, expected);
 }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -678,13 +678,7 @@ impl Value {
                 Ok(base)
             }
             // Flatten Mapping by flattening each value and inserting it into a new Mapping.
-            Self::Mapping(m) => {
-                let mut n = Mapping::new();
-                for (k, v) in m {
-                    n.insert(k.clone(), v.flattened()?)?;
-                }
-                Ok(Self::Mapping(n))
-            }
+            Self::Mapping(m) => Ok(Self::Mapping(m.flattened()?)),
             // Flatten Sequence by flattening each element and inserting it into a new Sequence
             Self::Sequence(s) => {
                 let mut n = Vec::with_capacity(s.len());

--- a/tests/inventory/classes/defaults.yml
+++ b/tests/inventory/classes/defaults.yml
@@ -1,0 +1,7 @@
+parameters:
+  fluentbit:
+    config:
+      inputs:
+        systemd:
+          foo: bar
+          baz: qux

--- a/tests/inventory/classes/meta.yml
+++ b/tests/inventory/classes/meta.yml
@@ -1,0 +1,2 @@
+classes:
+  - override

--- a/tests/inventory/classes/override.yml
+++ b/tests/inventory/classes/override.yml
@@ -1,0 +1,5 @@
+parameters:
+  fluentbit:
+    config:
+      inputs:
+        ~systemd: {}

--- a/tests/inventory/nodes/n24.yml
+++ b/tests/inventory/nodes/n24.yml
@@ -1,0 +1,4 @@
+classes:
+  - defaults
+  - meta
+parameters: {}

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -38,13 +38,16 @@ expected_classes = {
     "cluster.facts": ["n19"],
     "cluster.global": ["n19"],
     "config": ["n16"],
+    "defaults": ["n24"],
     "foo-indirect": ["n20"],
+    "meta": ["n24"],
     "nested.a": ["n8"],
     "nested.a_sub": ["n8", "n9"],
     "nested.b": ["n10"],
     "nested.cls1": ["n2"],
     "nested.cls2": ["n2"],
     "nonexisting": ["n18"],
+    "override": ["n24"],
     "yaml-anchor": ["n21"],
 }
 
@@ -57,7 +60,7 @@ expected_applications = {
     "d": ["n13"],
 }
 
-expected_nodes = set([f"n{i}" for i in range(1, 24)])
+expected_nodes = set([f"n{i}" for i in range(1, 25)])
 
 
 def test_inventory():


### PR DESCRIPTION
We introduce a new internal method `Mapping::flattened()` which is called from `Value::flattened()` for Mapping values. This method ensures that the flattened mapping retains the constant and overriding key information from the original mapping.

We also ensure that constant and overriding key information is propagated to the new mapping in `Mapping::interpolate()`.

Additionally, the PR updates all the node rendering test cases to have the correct sets of constant and overriding keys in the expected final parameters data and introduces a new node and associated classes in the test inventory which demonstrate a previously buggy configuration.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
