### PR TITLE
Use `map_err()` to propagate class loading error details to Python

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use serde::Deserialize;
 use std::path::PathBuf;
 // TODO(sg): Switch to serde_yaml's `apply_merge()` once it supports recursive merges, cf.
@@ -181,7 +181,7 @@ impl Node {
         meta.uri = format!("yaml_fs://{}", invpath.canonicalize()?.display());
         Ok(Some(
             Node::from_str(meta, Some(class_loc), &ccontents)
-                .with_context(|| format!("Deserializing {cls}"))?,
+                .map_err(|e| anyhow!("Deserializing {cls}: {e}"))?,
         ))
     }
 


### PR DESCRIPTION
We probably could access the context added by `with_context()` in `Reclass::nodeinfo()`, but since we use `map_err()` everywhere else, we simply switch to `map_err()` for consistency in the code base.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
