### PR TITLE
Improve error messages when reference resolution fails

### DIFF
--- a/src/refs/token_resolve_parse_tests.rs
+++ b/src/refs/token_resolve_parse_tests.rs
@@ -222,7 +222,7 @@ fn test_resolve_mapping_embedded() {
 }
 
 #[test]
-#[should_panic(expected = "Reference loop with reference paths [\"foo\"].")]
+#[should_panic(expected = "Detected reference loop with reference paths [\"foo\"].")]
 fn test_resolve_recursive_error() {
     let p = r#"
     foo: ${foo}
@@ -235,7 +235,7 @@ fn test_resolve_recursive_error() {
 }
 
 #[test]
-#[should_panic(expected = "Reference loop with reference paths [\"bar\", \"foo\"].")]
+#[should_panic(expected = "Detected reference loop with reference paths [\"bar\", \"foo\"].")]
 fn test_resolve_recursive_error_2() {
     let p = r#"
     foo: ${bar}
@@ -249,7 +249,7 @@ fn test_resolve_recursive_error_2() {
 }
 
 #[test]
-#[should_panic(expected = "Reference loop with reference paths [\"baz\", \"foo\"].")]
+#[should_panic(expected = "Detected reference loop with reference paths [\"baz\", \"foo\"].")]
 fn test_resolve_nested_recursive_error() {
     let p = r#"
     foo: ${baz}

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -387,6 +387,7 @@ impl Mapping {
             // either manage to interpolate a value (in which case it doesn't contain a loop) or we
             // don't and the whole interpolation is aborted.
             let mut st = state.clone();
+            st.push_mapping_key(k)?;
             let mut v = v.interpolate(root, &mut st)?;
             v.flatten()?;
             // Propagate key properties to the resulting mapping by using `insert_impl()`.

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -547,13 +547,14 @@ impl Value {
             Self::Sequence(s) => {
                 // Sequences are interpolated by calling interpolate() for each element.
                 let mut seq = vec![];
-                for it in s {
+                for (idx, it) in s.iter().enumerate() {
                     // References in separate entries in sequences can't form loops. Therefore we
                     // pass a copy of the current resolution state to the recursive call for each
                     // element. We don't need to update the input state after we're done with a
                     // Sequence either, since there's no potential to start recursing again, if
                     // we've fully interpolated a Sequence.
                     let mut st = state.clone();
+                    st.push_list_index(idx);
                     let e = it.interpolate(root, &mut st)?;
                     seq.push(e);
                 }
@@ -716,7 +717,7 @@ impl Value {
         let mut state = ResolveState::default();
         let mut v = self
             .interpolate(root, &mut state)
-            .map_err(|e| anyhow!("While resolving references in {self}: {e}"))?;
+            .map_err(|e| anyhow!("While resolving references: {e}"))?;
         v.flatten()?;
         Ok(v)
     }


### PR DESCRIPTION
To improve the error messages for reference resolution failure, we add a `Vec<String>` to track the current parameter key for which we're resolving references into the `ResolveState` struct.

We also extract the error rendering in `Token::resolve()` into methods on `ResolveState`, since we mostly need data from `ResolveState` to render the error messages.

The new error messages all print the parameter key for which we're resolving references. If applicable, the error messages also contain the full reference, and the particular key for which resolution failed.

To reduce repetition for the error handling, we also refactor `Token::resolve()` to always either interpolate or copy the Value which is the base for the key lookup. While this introduces a bunch of unnecessary calls to `clone()` if we're not doing a lookup into a `Value::String` or `Value::ValueList`, the performance impact is negligible, and the resulting code is much less convoluted.

Resolves #69

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
