### PR TITLE
Automatically set package version from Git tag

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -190,35 +190,11 @@ jobs:
           name: wheels
           path: dist
 
-  check-version:
-    name: Check if tag matches Cargo.toml version
-    runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/v')"
-    needs: [linux, windows, macos, sdist]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Extract Git version from ref
-        id: git_version
-        run: echo "version=$(echo ${GITHUB_REF#refs/tags/})" >> ${GITHUB_OUTPUT}
-        env:
-          GITHUB_REF: ${{ github.ref }}
-      - name: Read Cargo.toml
-        id: cargo_version
-        uses: SebRollen/toml-action@v1.0.2
-        with:
-          file: Cargo.toml
-          field: package.version
-      - name: Verify that tag matches Cargo.toml version
-        run: |
-          if [ "v${{ steps.cargo_version.outputs.value }}" != "${{ steps.git_version.outputs.version }}" ]; then
-            exit 1
-          fi
-
   release:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/v')"
-    needs: [check-version]
+    needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -106,7 +106,7 @@ jobs:
         env:
           VERSION: ${{ needs.get-version.outputs.version }}
         run: |
-          cargo set-version "${VERSION}"
+          cargo set-version "$env:VERSION"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,8 +19,22 @@ permissions:
   contents: read
 
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.genversion.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+      - name: Generate package version from Git tag
+        id: genversion
+        run: |
+          echo "version=$(git describe --tags --always --match=v* | sed 's/^v//' | cut -d- -f1,2)" >> "$GITHUB_OUTPUT"
+
   linux:
     runs-on: ubuntu-latest
+    needs: get-version
     strategy:
       matrix:
         target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
@@ -29,6 +43,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - uses: taiki-e/cache-cargo-install-action@v1
+        with:
+          tool: cargo-edit
+      - name: Set package version
+        env:
+          VERSION: ${{ needs.get-version.outputs.version }}
+        run: |
+          cargo set-version "${VERSION}"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -67,6 +89,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
+    needs: get-version
     strategy:
       matrix:
         target: [x64, x86]
@@ -76,6 +99,14 @@ jobs:
         with:
           python-version: '3.10'
           architecture: ${{ matrix.target }}
+      - uses: taiki-e/cache-cargo-install-action@v1
+        with:
+          tool: cargo-edit
+      - name: Set package version
+        env:
+          VERSION: ${{ needs.get-version.outputs.version }}
+        run: |
+          cargo set-version "${VERSION}"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -98,6 +129,7 @@ jobs:
 
   macos:
     runs-on: macos-latest
+    needs: get-version
     strategy:
       matrix:
         target: [x86_64, aarch64]
@@ -106,6 +138,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - uses: taiki-e/cache-cargo-install-action@v1
+        with:
+          tool: cargo-edit
+      - name: Set package version
+        env:
+          VERSION: ${{ needs.get-version.outputs.version }}
+        run: |
+          cargo set-version "${VERSION}"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -128,8 +168,17 @@ jobs:
 
   sdist:
     runs-on: ubuntu-latest
+    needs: get-version
     steps:
       - uses: actions/checkout@v4
+      - uses: taiki-e/cache-cargo-install-action@v1
+        with:
+          tool: cargo-edit
+      - name: Set package version
+        env:
+          VERSION: ${{ needs.get-version.outputs.version }}
+        run: |
+          cargo set-version "${VERSION}"
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,22 +12,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
-      - name: Extract Git version from ref
-        id: git_version
-        run: echo "version=$(echo ${GITHUB_REF#refs/tags/})" >> ${GITHUB_OUTPUT}
-        env:
-          GITHUB_REF: ${{ github.ref }}
-      - name: Read Cargo.toml
-        id: cargo_version
-        uses: SebRollen/toml-action@v1.0.2
-        with:
-          file: Cargo.toml
-          field: package.version
-      - name: Verify that tag matches Cargo.toml version
-        run: |
-          if [ "v${{ steps.cargo_version.outputs.value }}" != "${{ steps.git_version.outputs.version }}" ]; then
-            exit 1
-          fi
       - name: Build changelog from PRs with labels
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reclass-rs"
-version = "0.1.1"
+version = "0.0.0"
 edition = "2021"
 license = "BSD-3-Clause"
 authors = ["VSHN AG <info@vshn.ch>"]

--- a/README.md
+++ b/README.md
@@ -106,7 +106,23 @@ patch -p1 -d $KAPITAN_VENV < hack/kapitan_0.32_reclass_rs.patch
 
 Please note that we've only tested the patch against the Kapitan 0.32 release as published on PyPI.
 
+## Automated package version management
+
+We generate the package version of `reclass-rs` from the latest Git tag when building Python wheels.
+To ensure this always works, we keep the version in the committed `Cargo.toml` as `0.0.0`.
+
+We generate the package version from Git by calling `git describe --tags --always --match=v*`.
+This command produces something like `v0.1.1-61-g531ca91`.
+We always strip the leading `v`, since neither Cargo nor maturin support versions with leading `v`.
+If we're building a branch or PR, we discard the component derived from the commit hash.
+For the example output above, the package version for a branch or PR build will become `0.1.1.post61`.
+For tag builds, the command ouptut will be just the tag, so the package version will match the tag.
+
+The version is injected with [cargo-edit]'s `cargo set-version` before the Python wheels are built.
+
+See the ["Python" workflow](./.github/workflows/python.yml) for more details.
 
 [rustup]: https://rustup.rs/
 [maturin]: https://github.com/PyO3/maturin
 [Kapitan]: https://kapitan.dev
+[cargo-edit]: https://github.com/killercup/cargo-edit


### PR DESCRIPTION
We extract the version from Git with `git describe --tags --always --match=v*`, and generate a suitable version for Cargo/maturin from the returned value.

Resolves #42 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
