### PR TITLE
Refactor Reclass configuration options

### DIFF
--- a/benches/inventory_multi_threaded.rs
+++ b/benches/inventory_multi_threaded.rs
@@ -10,7 +10,7 @@ fn bench(c: &mut Criterion) {
         .unwrap();
 
     c.bench_function("Reclass::inventory() multi-threaded", |b| {
-        let r = Reclass::new("./tests/inventory/nodes", "./tests/inventory/classes", true).unwrap();
+        let r = Reclass::new("./tests/inventory", "nodes", "classes", true).unwrap();
         b.iter(|| black_box(r.render_inventory().unwrap()))
     });
 }

--- a/benches/inventory_single_threaded.rs
+++ b/benches/inventory_single_threaded.rs
@@ -10,7 +10,7 @@ fn bench(c: &mut Criterion) {
         .unwrap();
 
     c.bench_function("Reclass::inventory() single-threaded", |b| {
-        let r = Reclass::new("./tests/inventory/nodes", "./tests/inventory/classes", true).unwrap();
+        let r = Reclass::new("./tests/inventory", "nodes", "classes", true).unwrap();
         b.iter(|| black_box(r.render_inventory().unwrap()))
     });
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,13 @@ impl Config {
     }
 }
 
+#[pymethods]
+impl Config {
+    fn __repr__(&self) -> String {
+        format!("{self:#?}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,21 @@
+use anyhow::{anyhow, Result};
 use pyo3::prelude::*;
+use std::path::PathBuf;
+
+use crate::fsutil::to_lexical_normal;
 
 #[pyclass]
 #[derive(Clone, Debug, Default)]
 pub struct Config {
-    /// Path to node definitions in inventory
+    /// Base path of the inventory
+    #[pyo3(get)]
+    pub inventory_path: String,
+    /// Path to node definitions in the inventory. This should be a subdirectory of
+    /// `inventory_path`.
     #[pyo3(get)]
     pub nodes_path: String,
-    /// Path to class definitions in inventory
+    /// Path to class definitions in the inventory. This should be a subdirectory of
+    /// `inventory_path`.
     #[pyo3(get)]
     pub classes_path: String,
     /// Whether to ignore included classes which don't exist (yet)
@@ -15,11 +24,144 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(nodes_path: &str, classes_path: &str, ignore_class_notfound: bool) -> Self {
-        Self {
-            nodes_path: nodes_path.into(),
-            classes_path: classes_path.into(),
-            ignore_class_notfound,
+    /// Creates a new `Config` from the provided parameters.
+    ///
+    /// If neither `inventory_path` nor `classes_path` (or `nodes_path`) is given, the method
+    /// returns an error.
+    ///
+    /// If `inventory_path` is omitted, the component defaults to the current directory.
+    /// Config options `classes_path` and `nodes_path` are expected to be relative paths to
+    /// `inventory_path`. If these arguments are None, we default to `nodes` and `classes`
+    /// respectively. If `ignore_class_notfound` is None, we default the option to false.
+    pub fn new(
+        inventory_path: Option<&str>,
+        nodes_path: Option<&str>,
+        classes_path: Option<&str>,
+        ignore_class_notfound: Option<bool>,
+    ) -> Result<Self> {
+        if inventory_path.is_none() && nodes_path.is_none() {
+            return Err(anyhow!(
+                "One of inventory path and nodes path must be provided."
+            ));
         }
+        if inventory_path.is_none() && classes_path.is_none() {
+            return Err(anyhow!(
+                "One of inventory path and classes path must be provided."
+            ));
+        }
+        let inventory_path = inventory_path.unwrap_or(".");
+        let mut npath = PathBuf::from(inventory_path);
+        if let Some(p) = nodes_path {
+            npath.push(p);
+        } else {
+            npath.push("nodes");
+        };
+        let mut cpath = PathBuf::from(inventory_path);
+        if let Some(p) = classes_path {
+            cpath.push(p);
+        } else {
+            cpath.push("classes");
+        };
+        if npath == cpath || npath.starts_with(&cpath) || cpath.starts_with(&npath) {
+            return Err(anyhow!("Nodes and classes path must be non-overlapping."));
+        }
+        Ok(Self {
+            inventory_path: inventory_path.into(),
+            nodes_path: to_lexical_normal(&npath, true).display().to_string(),
+            classes_path: to_lexical_normal(&cpath, true).display().to_string(),
+            ignore_class_notfound: ignore_class_notfound.unwrap_or(false),
+        })
+    }
+
+    /// Construct path to node from `self.inventory_path`, `self.nodes_path` and the provided path
+    /// to the node relative to the inventory nodes directory.
+    pub(crate) fn node_path(&self, npath: &PathBuf) -> PathBuf {
+        let mut invpath = PathBuf::from(&self.nodes_path);
+        invpath.push(npath);
+        invpath
+    }
+
+    /// Construct path to class from `self.inventory_path`, `self.classes_path` and the provided
+    /// path to the class relative to the inventory classes directory.
+    pub(crate) fn class_path(&self, cpath: &PathBuf) -> PathBuf {
+        let mut invpath = PathBuf::from(&self.classes_path);
+        invpath.push(cpath);
+        invpath
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "One of inventory path and nodes path must be provided.")]
+    fn test_config_missing_nodes() {
+        let cfg = Config::new(None, None, None, None);
+        assert!(cfg.is_err());
+        cfg.unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "One of inventory path and classes path must be provided.")]
+    fn test_config_missing_classes() {
+        let cfg = Config::new(None, Some("nodes"), None, None);
+        assert!(cfg.is_err());
+        cfg.unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Nodes and classes path must be non-overlapping.")]
+    fn test_config_missing_non_overlapping_identical() {
+        let cfg = Config::new(None, Some("nodes"), Some("nodes"), None);
+        assert!(cfg.is_err());
+        cfg.unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Nodes and classes path must be non-overlapping.")]
+    fn test_config_missing_non_overlapping_nodes_parent() {
+        let cfg = Config::new(None, Some(""), Some("classes"), None);
+        assert!(cfg.is_err());
+        cfg.unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Nodes and classes path must be non-overlapping.")]
+    fn test_config_missing_non_overlapping_classes_parent() {
+        let cfg = Config::new(None, Some("nodes"), Some(""), None);
+        assert!(cfg.is_err());
+        cfg.unwrap();
+    }
+
+    #[test]
+    fn test_config_defaults() {
+        let cfg = Config::new(Some("./inventory"), None, None, None).unwrap();
+        assert_eq!(cfg.nodes_path, "./inventory/nodes");
+        assert_eq!(cfg.classes_path, "./inventory/classes");
+        assert_eq!(cfg.ignore_class_notfound, false);
+    }
+
+    #[test]
+    fn test_config_concatenate() {
+        let cfg =
+            Config::new(Some("./inventory"), Some("targets"), Some("settings"), None).unwrap();
+        assert_eq!(cfg.nodes_path, "./inventory/targets");
+        assert_eq!(cfg.classes_path, "./inventory/settings");
+        assert_eq!(cfg.ignore_class_notfound, false);
+    }
+
+    #[test]
+    fn test_config_normalize() {
+        let cfg = Config::new(
+            Some("./inventory"),
+            Some("targets/../targets/."),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(cfg.nodes_path, "./inventory/targets");
+        assert_eq!(cfg.classes_path, "./inventory/classes");
+        assert_eq!(cfg.ignore_class_notfound, false);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,25 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+#[derive(Clone, Debug, Default)]
+pub struct Config {
+    /// Path to node definitions in inventory
+    #[pyo3(get)]
+    pub nodes_path: String,
+    /// Path to class definitions in inventory
+    #[pyo3(get)]
+    pub classes_path: String,
+    /// Whether to ignore included classes which don't exist (yet)
+    #[pyo3(get)]
+    pub ignore_class_notfound: bool,
+}
+
+impl Config {
+    pub fn new(nodes_path: &str, classes_path: &str, ignore_class_notfound: bool) -> Self {
+        Self {
+            nodes_path: nodes_path.into(),
+            classes_path: classes_path.into(),
+            ignore_class_notfound,
+        }
+    }
+}

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+use std::path::{Component, Path, PathBuf};
+
+/// Converts `p` to a normalized path, but doesn't resolve symlinks. The function does normalize
+/// the path by resolving any `.` and `..` components which are present. If `preserve_prefix_cur`
+/// is `true`, a leading `./` of a relative path is preserved.
+///
+/// Use `to_lexical_absolute()` if you want to convert relative paths to absolute paths.
+pub(crate) fn to_lexical_normal(p: &Path, preserve_prefix_cur: bool) -> PathBuf {
+    let mut norm = PathBuf::new();
+    for (i, component) in p.components().enumerate() {
+        match component {
+            Component::CurDir => {
+                /* do nothing for `.` components */
+                if i == 0 && preserve_prefix_cur {
+                    norm.push(".");
+                }
+            }
+            Component::ParentDir => {
+                // pop the last element that we added for `..` components
+                norm.pop();
+            }
+            // just push the component for any other component
+            component => norm.push(component.as_os_str()),
+        }
+    }
+    norm
+}
+
+/// Converts `p` to an absolute path, but doesn't resolve symlinks. The function does normalize the
+/// path by resolving any `.` and `..` components which are present.
+///
+/// Copied from https://internals.rust-lang.org/t/path-to-lexical-absolute/14940.
+pub(crate) fn to_lexical_absolute(p: &Path) -> Result<PathBuf> {
+    let mut absolute = if p.is_absolute() {
+        PathBuf::new()
+    } else {
+        std::env::current_dir()?
+    };
+    absolute.push(to_lexical_normal(p, false));
+    Ok(absolute)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_lexical_absolute_for_absolute() {
+        let orig = "/foo/bar/../bar/baz";
+        let abs = to_lexical_absolute(&PathBuf::from(orig)).unwrap();
+        assert_eq!(abs, PathBuf::from("/foo/bar/baz"));
+    }
+
+    #[test]
+    fn test_to_lexical_normal_for_absolute() {
+        let orig = "/foo/bar/../bar/baz";
+        let abs = to_lexical_normal(&PathBuf::from(orig), false);
+        assert_eq!(abs, PathBuf::from("/foo/bar/baz"));
+    }
+
+    #[test]
+    fn test_to_lexical_absolute_for_relative() {
+        let orig = "foo/bar/../bar/baz";
+        let abs = to_lexical_absolute(&PathBuf::from(orig)).unwrap();
+        let mut base = std::env::current_dir().unwrap();
+        base.push("foo/bar/baz");
+        assert_eq!(abs, base);
+    }
+
+    #[test]
+    fn test_to_lexical_normal_for_relative() {
+        let orig = "foo/bar/../bar/baz";
+        let abs = to_lexical_normal(&PathBuf::from(orig), false);
+        assert_eq!(abs, PathBuf::from("foo/bar/baz"));
+        let orig = "./foo/bar/../bar/baz";
+        let abs = to_lexical_normal(&PathBuf::from(orig), false);
+        assert_eq!(abs, PathBuf::from("foo/bar/baz"));
+    }
+
+    #[test]
+    fn test_to_lexical_normal_for_relative_preserve_dot_prefix() {
+        let orig = "./foo/bar/../bar/baz";
+        let abs = to_lexical_normal(&PathBuf::from(orig), true);
+        assert_eq!(abs, PathBuf::from("./foo/bar/baz"));
+    }
+}

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -101,8 +101,9 @@ mod inventory_tests {
     #[test]
     fn test_render() {
         let r = Reclass::new(
-            "./tests/inventory/nodes",
-            "./tests/inventory/classes",
+            "./tests/inventory",
+            "nodes",
+            "classes",
             // n18 includes a nonexistent class
             true,
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,8 @@ impl Default for Reclass {
 fn reclass_rs(_py: Python, m: &PyModule) -> PyResult<()> {
     // Register the top-level `Reclass` Python class which is used to configure the library
     m.add_class::<Reclass>()?;
+    // Register the `Config` class
+    m.add_class::<Config>()?;
     // Register the NodeInfoMeta and NodeInfo classes
     m.add_class::<NodeInfoMeta>()?;
     m.add_class::<NodeInfo>()?;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -46,8 +46,7 @@ impl Node {
         let mut meta = NodeInfoMeta::new(name, name, "", "base");
 
         let npath = r.nodes.get(name).ok_or(anyhow!("Unknown node {name}"))?;
-        let mut invpath = PathBuf::from(&r.config.nodes_path);
-        invpath.push(npath);
+        let invpath = r.config.node_path(npath);
         let ncontents = std::fs::read_to_string(invpath.canonicalize()?)?;
 
         meta.uri = format!("yaml_fs://{}", to_lexical_absolute(&invpath)?.display());
@@ -173,8 +172,7 @@ impl Node {
         };
 
         // Render inventory path of class based from `r.classes_path`.
-        let mut invpath = PathBuf::from(&r.config.classes_path);
-        invpath.push(cpath);
+        let invpath = r.config.class_path(cpath);
 
         // Load file contents and create Node
         let mut meta = NodeInfoMeta::default();
@@ -306,12 +304,7 @@ impl Node {
 
 #[cfg(test)]
 fn make_reclass() -> Reclass {
-    Reclass::new(
-        "./tests/inventory/nodes",
-        "./tests/inventory/classes",
-        false,
-    )
-    .unwrap()
+    Reclass::new("./tests/inventory", "nodes", "classes", false).unwrap()
 }
 
 #[cfg(test)]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -5,10 +5,11 @@ use std::path::PathBuf;
 // https://github.com/dtolnay/serde-yaml/issues/362
 use yaml_merge_keys::merge_keys_serde;
 
+use crate::fsutil::to_lexical_absolute;
 use crate::list::{List, RemovableList, UniqueList};
 use crate::refs::{ResolveState, Token};
 use crate::types::{Mapping, Value};
-use crate::{to_lexical_absolute, Reclass};
+use crate::Reclass;
 
 mod nodeinfo;
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -45,7 +45,7 @@ impl Node {
         let mut meta = NodeInfoMeta::new(name, name, "", "base");
 
         let npath = r.nodes.get(name).ok_or(anyhow!("Unknown node {name}"))?;
-        let mut invpath = PathBuf::from(&r.nodes_path);
+        let mut invpath = PathBuf::from(&r.config.nodes_path);
         invpath.push(npath);
         let ncontents = std::fs::read_to_string(invpath.canonicalize()?)?;
 
@@ -157,7 +157,7 @@ impl Node {
 
         // Lookup path for provided class in r.classes, handling ignore_class_notfound
         let Some(cpath) = r.classes.get(&cls) else {
-            if r.ignore_class_notfound {
+            if r.config.ignore_class_notfound {
                 return Ok(None);
             }
             return Err(anyhow!("Class {cls} not found"));
@@ -172,7 +172,7 @@ impl Node {
         };
 
         // Render inventory path of class based from `r.classes_path`.
-        let mut invpath = PathBuf::from(&r.classes_path);
+        let mut invpath = PathBuf::from(&r.config.classes_path);
         invpath.push(cpath);
 
         // Load file contents and create Node

--- a/src/node/node_render_tests.rs
+++ b/src/node/node_render_tests.rs
@@ -462,7 +462,7 @@ fn test_render_n17() {
 
 #[test]
 fn test_render_n18() {
-    let r = Reclass::new("./tests/inventory/nodes", "./tests/inventory/classes", true).unwrap();
+    let r = Reclass::new("./tests/inventory", "nodes", "classes", true).unwrap();
     let n = r.render_node("n18").unwrap();
 
     // # Parameters

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -8,9 +8,10 @@ def test_import_new():
         "./tests/inventory/targets", "./tests/inventory/classes", True
     )
     assert r is not None
-    assert r.nodes_path == "./tests/inventory/targets"
-    assert r.classes_path == "./tests/inventory/classes"
-    assert r.ignore_class_notfound
+    assert r.config is not None
+    assert r.config.nodes_path == "./tests/inventory/targets"
+    assert r.config.classes_path == "./tests/inventory/classes"
+    assert r.config.ignore_class_notfound
 
 
 def test_import_raises():

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,21 +1,27 @@
 import reclass_rs
 import pytest
 import os
+import pathlib
 
 
 def test_import_new():
     r = reclass_rs.Reclass(
-        "./tests/inventory/targets", "./tests/inventory/classes", True
+        "./tests/inventory",
+        "targets",
+        "classes",
+        True,
     )
+    invpath = pathlib.Path("./tests/inventory")
     assert r is not None
     assert r.config is not None
-    assert r.config.nodes_path == "./tests/inventory/targets"
-    assert r.config.classes_path == "./tests/inventory/classes"
+    assert pathlib.Path(r.config.inventory_path) == invpath
+    assert pathlib.Path(r.config.nodes_path) == invpath / "targets"
+    assert pathlib.Path(r.config.classes_path) == invpath / "classes"
     assert r.config.ignore_class_notfound
 
 
 def test_import_raises():
     with pytest.raises(ValueError) as exc:
-        r = reclass_rs.Reclass("./foo", "./bar")
+        r = reclass_rs.Reclass("./inventory", "foo", "bar")
 
     assert "Error while discovering nodes" in str(exc.value)

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -65,8 +65,7 @@ expected_nodes = set([f"n{i}" for i in range(1, 25)])
 
 def test_inventory():
     r = reclass_rs.Reclass(
-        nodes_path="./tests/inventory/nodes",
-        classes_path="./tests/inventory/classes",
+        inventory_path="./tests/inventory",
         ignore_class_notfound=True,
     )
     inv = r.inventory()
@@ -80,8 +79,7 @@ def test_inventory():
 
 def test_inventory_as_dict():
     r = reclass_rs.Reclass(
-        nodes_path="./tests/inventory/nodes",
-        classes_path="./tests/inventory/classes",
+        inventory_path="./tests/inventory",
         ignore_class_notfound=True,
     )
     inv = r.inventory().as_dict()

--- a/tests/test_nodeinfo.py
+++ b/tests/test_nodeinfo.py
@@ -4,6 +4,28 @@ from pathlib import Path
 
 
 def test_nodeinfo_n1():
+    r = reclass_rs.Reclass(inventory_path="./tests/inventory")
+    n = r.nodeinfo("n1")
+    npath = Path("./tests/inventory/nodes/n1.yml").resolve()
+    assert n.__reclass__.uri == f"yaml_fs://{npath}"
+    assert n.applications == ["app1", "app2"]
+    assert n.classes == ["cls1", "cls2"]
+    assert n.parameters == {
+        "_reclass_": {
+            "environment": "base",
+            "name": {
+                "full": "n1",
+                "parts": ["n1"],
+                "path": "n1",
+                "short": "n1",
+            },
+        },
+        "foo": {"foo": "foo", "bar": "cls2", "baz": "cls1"},
+        "bar": {"foo": "foo"},
+    }
+
+
+def test_nodeinfo_n1_no_invpath():
     r = reclass_rs.Reclass(
         nodes_path="./tests/inventory/nodes", classes_path="./tests/inventory/classes"
     )
@@ -28,18 +50,14 @@ def test_nodeinfo_n1():
 
 
 def test_nodeinfo_n1_meta_symlink():
-    r = reclass_rs.Reclass(
-        nodes_path="./tests/inventory/targets", classes_path="./tests/inventory/classes"
-    )
+    r = reclass_rs.Reclass(inventory_path="./tests/inventory", nodes_path="targets")
     n = r.nodeinfo("n1")
     npath = Path("./tests/inventory/targets/n1.yml").absolute()
     assert n.__reclass__.uri == f"yaml_fs://{npath}"
 
 
 def test_nodeinfo_n2():
-    r = reclass_rs.Reclass(
-        nodes_path="./tests/inventory/nodes", classes_path="./tests/inventory/classes"
-    )
+    r = reclass_rs.Reclass(inventory_path="./tests/inventory")
     n = r.nodeinfo("n2")
     assert n.applications == []
     assert n.classes == ["nested.cls2", "nested.cls1"]
@@ -59,9 +77,7 @@ def test_nodeinfo_n2():
 
 
 def test_nodeinfo_n3():
-    r = reclass_rs.Reclass(
-        nodes_path="./tests/inventory/nodes", classes_path="./tests/inventory/classes"
-    )
+    r = reclass_rs.Reclass(inventory_path="./tests/inventory")
     n = r.nodeinfo("n3")
     assert n.applications == []
     assert n.classes == ["cls4", "cls5", "cls6", "cls3"]
@@ -88,9 +104,7 @@ def test_nodeinfo_n3():
 
 
 def test_nodeinfo_n4():
-    r = reclass_rs.Reclass(
-        nodes_path="./tests/inventory/nodes", classes_path="./tests/inventory/classes"
-    )
+    r = reclass_rs.Reclass(inventory_path="./tests/inventory")
     n = r.nodeinfo("n4")
     assert n.applications == []
     assert n.classes == ["cls8", "${qux}", "cls7"]

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -7,13 +7,9 @@ use reclass_rs::Reclass;
 fn test_reclass() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let r = Reclass::new(
-            "./tests/inventory/nodes",
-            "./tests/inventory/classes",
-            false,
-        )
-        .unwrap()
-        .into_py(py);
+        let r = Reclass::new("./tests/inventory", "nodes", "classes", false)
+            .unwrap()
+            .into_py(py);
         let locals = PyDict::new(py);
         locals.set_item("r", r).unwrap();
         py.run(


### PR DESCRIPTION
We introduce a new `Config` struct, which holds the configuration parameters supplied by the user. Additonally, we introduce a new config field `inventory_path`.

We try to match handling of `inventory_path`, `nodes_path`, and `classes_path` to Python reclass's (and Kapitan's) behavior.

This is a breaking change because config options `nodes_path` and `classes_path` are now treated as relative paths to the new config option `inventory_path`. Since we choose default value `.` for `inventory_path` for the Python constructor for reclass-rs, this also changes the default values for `nodes_path` and `classes_path` from `./inventory/nodes` and `./inventory/classes` to `./nodes` and `./classes`.

However, because Kapitan concatenates the user-supplied `inventory_path` with the default relative `nodes_path` and `classes_path` (or their user-supplied overrides which are loaded from `<inventory_path>/reclass-config.yml`), the existing patch for enabling reclass-rs in Kapitan 0.32 doesn't need to be modified since treating the concatenated paths as relative to the current directory matches the old behavior of reclass-rs.

## Research notes on Python reclass / Kapitan behavior

<details>
<summary>Python reclass semantics</summary>

Python reclass (as far as I'm able to determine) has the following semantics:

* One of `inventory_path` or (`nodes_path` && `classes_path`) must be given
* If `inventory_path` isn't given, nodes/classes paths are resolved relative to the current working directory
* If `nodes_path` or `classes_path` isn't given, but `inventory_path` is given, `<inventory_path>/nodes` and `<inventory_path>/classes` are used respectively.
* If both are given, Python reclass concatenates the inventory path with the nodes/classes path. Reclass expects that nodes/classes path are relative to `inventory_path`.
* Reclass verifies that the final `nodes_path` and `classes_path` are non-overlapping (i.e. not the same directory, and not either a parent of the other)
</details>

<details>
<summary>Additional Kapitan semantics</summary>

Kapitan adds the following semantics:

* Kapitan reads reclass config options from file `<inventory_path>/reclass-config.yml` if it exists.
* Kapitan always sets `nodes_path` and `classes_path` explicitly, and normalizes (with Python's `os.path.normpath()`) user-provided `nodes_path` and `classes_path` before passing them to Reclass.
  * Kapitan prepends `inventory_path` to `nodes_path` and `classes_path` before providing them to Reclass (since that's the format that reclass.get_storage()` expects)
  * `~` or `~user` in nodes/classes path isn't resolved by Kapitan before passing the config to Reclass.
* Kapitan uses `./inventory` as the `inventory_path` if nothing else is specified
* Kapitan doesn't invoke a Python reclass API which looks at the inventory path option (as far as I can tell).
* The Reclass API which is invoked by Kapitan doesn't resolve `~` or `~user` in the nodes or classes path either.
</details>

## TODO

- [x] Write tests to verify that our path option handling matches Python reclass / Kapitan
- [x] Check if this is really a breaking change and adjust PR label accordingly

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
