### PR TITLE
Treat `foo/init.yml` as content for class `foo`

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -115,7 +115,7 @@ mod inventory_tests {
         let mut nodes = inv.nodes.keys().cloned().collect::<Vec<String>>();
         nodes.sort();
 
-        let mut expected_nodes = (1..=24).map(|n| format!("n{n}")).collect::<Vec<String>>();
+        let mut expected_nodes = (1..=25).map(|n| format!("n{n}")).collect::<Vec<String>>();
         expected_nodes.sort();
 
         assert_eq!(nodes, expected_nodes);
@@ -148,6 +148,7 @@ mod inventory_tests {
         expected_classes.insert("\\${baz}".into(), vec!["n17".into()]);
         expected_classes.insert("app1".into(), vec!["n12".into()]);
         expected_classes.insert("app2".into(), vec!["n13".into()]);
+        expected_classes.insert("bar".into(), vec!["n25".into()]);
         expected_classes.insert("cls1".into(), vec!["n1".into()]);
         expected_classes.insert("cls2".into(), vec!["n1".into()]);
         expected_classes.insert("cls3".into(), vec!["n3".into()]);
@@ -183,6 +184,7 @@ mod inventory_tests {
         expected_classes.insert("cluster.global".into(), vec!["n19".into()]);
         expected_classes.insert("config".into(), vec!["n16".into()]);
         expected_classes.insert("defaults".into(), vec!["n24".into()]);
+        expected_classes.insert("foo".into(), vec!["n25".into()]);
         expected_classes.insert("foo-indirect".into(), vec!["n20".into()]);
         expected_classes.insert("meta".into(), vec!["n24".into()]);
         expected_classes.insert("nested.a".into(), vec!["n8".into()]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,12 @@ use node::{Node, NodeInfo, NodeInfoMeta};
 
 const SUPPORTED_YAML_EXTS: [&str; 2] = ["yml", "yaml"];
 
+#[derive(Clone, Debug)]
+struct EntityInfo {
+    path: PathBuf,
+    loc: PathBuf,
+}
+
 /// This struct holds configuration fields for various library behaviors
 #[pyclass]
 #[derive(Clone, Debug)]
@@ -39,9 +45,9 @@ pub struct Reclass {
     #[pyo3(get)]
     pub config: Config,
     /// List of discovered Reclass classes in `classes_path`
-    classes: HashMap<String, PathBuf>,
+    classes: HashMap<String, EntityInfo>,
     /// List of discovered Reclass nodes in `nodes_path`
-    nodes: HashMap<String, PathBuf>,
+    nodes: HashMap<String, EntityInfo>,
 }
 
 fn err_duplicate_entity(root: &str, relpath: &Path, cls: &str, prev: &Path) -> Result<()> {
@@ -71,7 +77,7 @@ fn err_duplicate_entity(root: &str, relpath: &Path, cls: &str, prev: &Path) -> R
 
 fn walk_entity_dir(
     root: &str,
-    entity_map: &mut HashMap<String, PathBuf>,
+    entity_map: &mut HashMap<String, EntityInfo>,
     max_depth: usize,
 ) -> Result<()> {
     let entity_root = to_lexical_absolute(&PathBuf::from(root))?;
@@ -98,10 +104,17 @@ fn walk_entity_dir(
                     entry.path().display()
                 ))?
                 .replace(MAIN_SEPARATOR, ".");
+            let loc = relpath.parent().unwrap_or(Path::new(""));
             if let Some(prev) = entity_map.get(&cls) {
-                return err_duplicate_entity(root, relpath, &cls, prev);
+                return err_duplicate_entity(root, relpath, &cls, &prev.path);
             }
-            entity_map.insert(cls, relpath.to_path_buf());
+            entity_map.insert(
+                cls,
+                EntityInfo {
+                    path: relpath.to_path_buf(),
+                    loc: PathBuf::from(loc),
+                },
+            );
         }
     }
     Ok(())

--- a/src/node/node_render_tests.rs
+++ b/src/node/node_render_tests.rs
@@ -610,3 +610,21 @@ fn test_render_n24() {
     );
     assert_eq!(n.parameters, expected);
 }
+
+#[test]
+fn test_render_n25() {
+    let r = make_reclass();
+    let n = r.render_node("n25").unwrap();
+
+    let expected = expected_params(
+        "n25",
+        r#"
+        foo:
+          foo: foo/init
+          bar: bar
+        "#,
+    );
+    println!("{:#?}", n.parameters);
+    assert_eq!(n.parameters, expected);
+    assert_eq!(n.classes, vec!["bar", "foo"]);
+}

--- a/tests/inventory/classes/bar.yml
+++ b/tests/inventory/classes/bar.yml
@@ -1,0 +1,3 @@
+parameters:
+  foo:
+    bar: bar

--- a/tests/inventory/classes/foo/init.yml
+++ b/tests/inventory/classes/foo/init.yml
@@ -1,0 +1,8 @@
+classes:
+  # this is resolved to top-level `bar`, because content in `foo/init.yml` is
+  # treated exactly as if it were defined as `foo.yml`.
+  - .bar
+
+parameters:
+  foo:
+    foo: foo/init

--- a/tests/inventory/nodes/n25.yml
+++ b/tests/inventory/nodes/n25.yml
@@ -1,0 +1,2 @@
+classes:
+  - foo

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -7,6 +7,7 @@ expected_classes = {
     "${qux}": ["n4"],
     "app1": ["n12"],
     "app2": ["n13"],
+    "bar": ["n25"],
     "cls1": ["n1"],
     "cls2": ["n1"],
     "cls3": ["n3"],
@@ -39,6 +40,7 @@ expected_classes = {
     "cluster.global": ["n19"],
     "config": ["n16"],
     "defaults": ["n24"],
+    "foo": ["n25"],
     "foo-indirect": ["n20"],
     "meta": ["n24"],
     "nested.a": ["n8"],
@@ -60,7 +62,7 @@ expected_applications = {
     "d": ["n13"],
 }
 
-expected_nodes = set([f"n{i}" for i in range(1, 25)])
+expected_nodes = set([f"n{i}" for i in range(1, 26)])
 
 
 def test_inventory():


### PR DESCRIPTION
This ensures that the behavior of reclass-rs matches Python reclass in regards to how files named `init.yml` (or `init.yaml`) are treated.

Python reclass treats such files as content for class `foo`. While Project Syn doesn't make use of this mapping and instead favors having a file `foo.yml` alongside a folder `foo/` to achieve the same behavior, we want to ensure that reclass-rs is compatible with as many Reclass inventories as possible.

Notably, Python reclass also resolves relative includes in such files as relative to the parent directory of the directory containing the file. For example, relative includes in `foo/init.yml` are treated relative to the directory holding `foo` and not relative to directory `foo`.

This is a breaking change for users which rely on the current reclass-rs behavior of handling files named `init.yml`, since such files can no longer be included as `foo.init`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
