### PR TITLE
Add support for config option `compose-node-name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ The implementation currently supports the following features of Kapicorp Reclass
 * References in class names
 * Loading classes with relative names
 * Loading Reclass configuration options from `reclass-config.yaml`
+* The Reclass option `componse_node_name`
+** reclass-rs provides a non-compatible mode for `compose_node_name` which preserves literal dots in node names
 
 The following Kapicorp Reclass features aren't supported:
 
 * Ignoring overwritten missing references
 * Inventory Queries
 * The Reclass option `ignore_class_notfound_regexp`
-* The Reclass option `componse_node_name`
 * The Reclass option `allow_none_override` can't be set to `False`
 * The Reclass `yaml_git` and `mixed` storage types
 * Any Reclass option which is not mentioned explicitly here or above

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,9 @@ pub struct Config {
     /// Whether to ignore included classes which don't exist (yet)
     #[pyo3(get)]
     pub ignore_class_notfound: bool,
+    /// Whether to treat nested files in `nodes_path` as node definitions
+    #[pyo3(get)]
+    pub compose_node_name: bool,
 }
 
 impl Config {
@@ -70,6 +73,7 @@ impl Config {
             nodes_path: to_lexical_normal(&npath, true).display().to_string(),
             classes_path: to_lexical_normal(&cpath, true).display().to_string(),
             ignore_class_notfound: ignore_class_notfound.unwrap_or(false),
+            compose_node_name: false,
         })
     }
 
@@ -111,6 +115,11 @@ impl Config {
                 "ignore_class_notfound" => {
                     self.ignore_class_notfound = v.as_bool().ok_or(anyhow!(
                         "Expected value of config key 'ignore_class_notfound' to be a boolean"
+                    ))?;
+                }
+                "compose_node_name" => {
+                    self.compose_node_name = v.as_bool().ok_or(anyhow!(
+                        "Expected value of config key 'compose_node_name' to be a boolean"
                     ))?;
                 }
                 _ => {

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -203,6 +203,57 @@ mod inventory_tests {
         Value::Sequence(i.iter().map(|s| literal(s)).collect::<Vec<Value>>())
     }
 
+    fn check_compose_node_name_shared(inv: &Inventory, invabsdir: &str) {
+        let mut nodes = inv.nodes.keys().collect::<Vec<_>>();
+        nodes.sort();
+        assert_eq!(
+            nodes,
+            vec!["a", "a.1", "b.1", "c.1", "c._c.1", "d", "d1", "d2"]
+        );
+
+        for n in nodes {
+            if n == "a.1" {
+                // not checking a.1 here, since it's the one node that is rendered differently
+                // between compat- and nocompat-mode.
+                continue;
+            }
+            let node = &inv.nodes[n];
+            assert_eq!(node.reclass.node, *n);
+            assert_eq!(node.reclass.name, *n);
+            let expected_full_name = node.parameters.get(&"node_name".into()).unwrap();
+            let expected_short_name = node.parameters.get(&"short_name".into()).unwrap();
+            let expected_path = node.parameters.get(&"path".into()).unwrap();
+            let expected_parts = node.parameters.get(&"parts".into()).unwrap();
+            let expected_uri_suffix = node.parameters.get(&"uri_suffix".into()).unwrap();
+            assert_eq!(
+                node.reclass.uri,
+                format!(
+                    "yaml_fs://{invabsdir}/nodes/{}",
+                    expected_uri_suffix.as_str().unwrap()
+                )
+            );
+            let params_reclass_name = node
+                .parameters
+                .get(&"_reclass_".into())
+                .unwrap()
+                .get(&"name".into())
+                .unwrap();
+            assert_eq!(
+                params_reclass_name.get(&"full".into()),
+                Some(expected_full_name)
+            );
+            assert_eq!(
+                params_reclass_name.get(&"short".into()),
+                Some(expected_short_name)
+            );
+            assert_eq!(params_reclass_name.get(&"path".into()), Some(expected_path));
+            assert_eq!(
+                params_reclass_name.get(&"parts".into()),
+                Some(expected_parts)
+            )
+        }
+    }
+
     #[test]
     fn test_render_compose_node_name_pycompat() {
         let mut c = crate::Config::new(
@@ -214,36 +265,12 @@ mod inventory_tests {
         .unwrap();
         c.load_from_file("reclass-config-compat.yml").unwrap();
         let r = Reclass::new_from_config(c).unwrap();
+
+        let inv = Inventory::render(&r).unwrap();
+
         let invabsdir = std::fs::canonicalize("./tests/inventory-compose-node-name").unwrap();
         let invabsdir = invabsdir.to_str().unwrap();
-        let inv = Inventory::render(&r).unwrap();
-        let mut nodes = inv.nodes.keys().collect::<Vec<_>>();
-        nodes.sort();
-        assert_eq!(nodes, vec!["a", "a.1", "b.1", "c.1", "d"]);
-
-        let node = &inv.nodes["a"];
-        assert_eq!(node.reclass.node, "a");
-        assert_eq!(node.reclass.name, "a");
-        assert_eq!(
-            node.reclass.uri,
-            format!("yaml_fs://{invabsdir}/nodes/a.yml")
-        );
-        let params_reclass_name = node
-            .parameters
-            .get(&"_reclass_".into())
-            .unwrap()
-            .get(&"name".into())
-            .unwrap();
-        assert_eq!(params_reclass_name.get(&"full".into()), Some(&literal("a")));
-        assert_eq!(
-            params_reclass_name.get(&"short".into()),
-            Some(&literal("a"))
-        );
-        assert_eq!(params_reclass_name.get(&"path".into()), Some(&literal("a")));
-        assert_eq!(
-            params_reclass_name.get(&"parts".into()),
-            Some(&sequence(&["a"]))
-        );
+        check_compose_node_name_shared(&inv, invabsdir);
 
         let node = &inv.nodes["a.1"];
         assert_eq!(node.reclass.node, "a.1");
@@ -287,36 +314,12 @@ mod inventory_tests {
         .unwrap();
         c.load_from_file("reclass-config.yml").unwrap();
         let r = Reclass::new_from_config(c).unwrap();
+
+        let inv = Inventory::render(&r).unwrap();
+
         let invabsdir = std::fs::canonicalize("./tests/inventory-compose-node-name").unwrap();
         let invabsdir = invabsdir.to_str().unwrap();
-        let inv = Inventory::render(&r).unwrap();
-        let mut nodes = inv.nodes.keys().collect::<Vec<_>>();
-        nodes.sort();
-        assert_eq!(nodes, vec!["a", "a.1", "b.1", "c.1", "d"]);
-
-        let node = &inv.nodes["a"];
-        assert_eq!(node.reclass.node, "a");
-        assert_eq!(node.reclass.name, "a");
-        assert_eq!(
-            node.reclass.uri,
-            format!("yaml_fs://{invabsdir}/nodes/a.yml")
-        );
-        let params_reclass_name = node
-            .parameters
-            .get(&"_reclass_".into())
-            .unwrap()
-            .get(&"name".into())
-            .unwrap();
-        assert_eq!(params_reclass_name.get(&"full".into()), Some(&literal("a")));
-        assert_eq!(
-            params_reclass_name.get(&"short".into()),
-            Some(&literal("a"))
-        );
-        assert_eq!(params_reclass_name.get(&"path".into()), Some(&literal("a")));
-        assert_eq!(
-            params_reclass_name.get(&"parts".into()),
-            Some(&sequence(&["a"]))
-        );
+        check_compose_node_name_shared(&inv, invabsdir);
 
         let node = &inv.nodes["a.1"];
         assert_eq!(node.reclass.node, "a.1");

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -212,9 +212,7 @@ mod inventory_tests {
             None,
         )
         .unwrap();
-        c.load_from_file("reclass-config.yml").unwrap();
-        c.compatflags
-            .insert(crate::config::CompatFlag::ComposeNodeNameLiteralDots);
+        c.load_from_file("reclass-config-compat.yml").unwrap();
         let r = Reclass::new_from_config(c).unwrap();
         let invabsdir = std::fs::canonicalize("./tests/inventory-compose-node-name").unwrap();
         let invabsdir = invabsdir.to_str().unwrap();

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -204,7 +204,7 @@ mod inventory_tests {
     }
 
     #[test]
-    fn test_render_compose_node_name() {
+    fn test_render_compose_node_name_pycompat() {
         let mut c = crate::Config::new(
             Some("./tests/inventory-compose-node-name"),
             None,
@@ -213,6 +213,8 @@ mod inventory_tests {
         )
         .unwrap();
         c.load_from_file("reclass-config.yml").unwrap();
+        c.compatflags
+            .insert(crate::config::CompatFlag::ComposeNodeNameLiteralDots);
         let r = Reclass::new_from_config(c).unwrap();
         let invabsdir = std::fs::canonicalize("./tests/inventory-compose-node-name").unwrap();
         let invabsdir = invabsdir.to_str().unwrap();
@@ -273,6 +275,79 @@ mod inventory_tests {
         assert_eq!(
             params_reclass_name.get(&"parts".into()),
             Some(&sequence(&["a", "1"]))
+        );
+    }
+
+    #[test]
+    fn test_render_compose_node_name() {
+        let mut c = crate::Config::new(
+            Some("./tests/inventory-compose-node-name"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        c.load_from_file("reclass-config.yml").unwrap();
+        let r = Reclass::new_from_config(c).unwrap();
+        let invabsdir = std::fs::canonicalize("./tests/inventory-compose-node-name").unwrap();
+        let invabsdir = invabsdir.to_str().unwrap();
+        let inv = Inventory::render(&r).unwrap();
+        let mut nodes = inv.nodes.keys().collect::<Vec<_>>();
+        nodes.sort();
+        assert_eq!(nodes, vec!["a", "a.1", "b.1", "c.1", "d"]);
+
+        let node = &inv.nodes["a"];
+        assert_eq!(node.reclass.node, "a");
+        assert_eq!(node.reclass.name, "a");
+        assert_eq!(
+            node.reclass.uri,
+            format!("yaml_fs://{invabsdir}/nodes/a.yml")
+        );
+        let params_reclass_name = node
+            .parameters
+            .get(&"_reclass_".into())
+            .unwrap()
+            .get(&"name".into())
+            .unwrap();
+        assert_eq!(params_reclass_name.get(&"full".into()), Some(&literal("a")));
+        assert_eq!(
+            params_reclass_name.get(&"short".into()),
+            Some(&literal("a"))
+        );
+        assert_eq!(params_reclass_name.get(&"path".into()), Some(&literal("a")));
+        assert_eq!(
+            params_reclass_name.get(&"parts".into()),
+            Some(&sequence(&["a"]))
+        );
+
+        let node = &inv.nodes["a.1"];
+        assert_eq!(node.reclass.node, "a.1");
+        assert_eq!(node.reclass.name, "a.1");
+        assert_eq!(
+            node.reclass.uri,
+            format!("yaml_fs://{invabsdir}/nodes/a.1.yml")
+        );
+        let params_reclass_name = node
+            .parameters
+            .get(&"_reclass_".into())
+            .unwrap()
+            .get(&"name".into())
+            .unwrap();
+        assert_eq!(
+            params_reclass_name.get(&"full".into()),
+            Some(&literal("a.1"))
+        );
+        assert_eq!(
+            params_reclass_name.get(&"short".into()),
+            Some(&literal("a.1"))
+        );
+        assert_eq!(
+            params_reclass_name.get(&"path".into()),
+            Some(&literal("a.1"))
+        );
+        assert_eq!(
+            params_reclass_name.get(&"parts".into()),
+            Some(&sequence(&["a.1"]))
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use walkdir::WalkDir;
 
-use config::Config;
+use config::{CompatFlag, Config};
 use fsutil::to_lexical_absolute;
 use inventory::Inventory;
 use node::{Node, NodeInfo, NodeInfoMeta};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,21 @@ impl Reclass {
             eprintln!("While initializing global thread pool: {e}");
         }
     }
+
+    /// Sets the provided CompatFlag in the current Reclass instance's config object
+    pub fn set_compat_flag(&mut self, flag: CompatFlag) {
+        self.config.compatflags.insert(flag);
+    }
+
+    /// Unsets the provided CompatFlag in the current Reclass instance's config object
+    pub fn unset_compat_flag(&mut self, flag: &CompatFlag) {
+        self.config.compatflags.remove(flag);
+    }
+
+    /// Clears the compatflags set in the current Reclass instance's config object
+    pub fn clear_compat_flags(&mut self) {
+        self.config.compatflags.clear();
+    }
 }
 
 impl Default for Reclass {
@@ -326,8 +341,9 @@ impl Default for Reclass {
 fn reclass_rs(_py: Python, m: &PyModule) -> PyResult<()> {
     // Register the top-level `Reclass` Python class which is used to configure the library
     m.add_class::<Reclass>()?;
-    // Register the `Config` class
+    // Register the `Config` class and `CompatFlag` enum
     m.add_class::<Config>()?;
+    m.add_class::<CompatFlag>()?;
     // Register the NodeInfoMeta and NodeInfo classes
     m.add_class::<NodeInfoMeta>()?;
     m.add_class::<NodeInfo>()?;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -5,10 +5,11 @@ use std::path::PathBuf;
 // https://github.com/dtolnay/serde-yaml/issues/362
 use yaml_merge_keys::merge_keys_serde;
 
+use crate::fsutil::to_lexical_absolute;
 use crate::list::{List, RemovableList, UniqueList};
 use crate::refs::{ResolveState, Token};
 use crate::types::{Mapping, Value};
-use crate::{to_lexical_absolute, Reclass};
+use crate::Reclass;
 
 mod nodeinfo;
 
@@ -47,7 +48,7 @@ impl Node {
         let ncontents = std::fs::read_to_string(invpath.canonicalize()?)?;
 
         let uri = format!("yaml_fs://{}", to_lexical_absolute(&invpath)?.display());
-        let meta = NodeInfoMeta::new(name, name, &uri, "base");
+        let meta = NodeInfoMeta::new(name, name, &uri, nodeinfo.path.with_extension(""), "base");
         Node::from_str(meta, None, &ncontents)
     }
 
@@ -281,7 +282,7 @@ impl Node {
         // class loading. This roughly corresponds to Python reclass's
         // `_get_automatic_parameters()`.
         base.parameters
-            .insert("_reclass_".into(), self.meta.as_reclass()?.into())?;
+            .insert("_reclass_".into(), self.meta.as_reclass(&r.config)?.into())?;
 
         let mut seen = vec![];
         let mut root = Node::default();

--- a/src/node/nodeinfo.rs
+++ b/src/node/nodeinfo.rs
@@ -51,6 +51,13 @@ impl NodeInfoMeta {
 
     /// Generates a Mapping suitable to use as meta parameter `_reclass_`
     pub(crate) fn as_reclass(&self, config: &Config) -> Result<Mapping> {
+        let part0 = self
+            .parts
+            .iter()
+            .next()
+            .ok_or(anyhow!("Can't extract first path segment for node"))?
+            .to_str()
+            .ok_or(anyhow!("Unable to convert path segment to a string"))?;
         let parts = if config.compose_node_name
             && config
                 .compatflags
@@ -61,6 +68,15 @@ impl NodeInfoMeta {
             // This matches Python reclass's behavior, but is incorrect for nodes which contain
             // literal dots in the file name.
             self.name.split('.').collect::<Vec<&str>>()
+        } else if part0.starts_with('_') {
+            // Always drop path prefix for paths that start with `_`
+            vec![self
+                .parts
+                .iter()
+                .last()
+                .ok_or(anyhow!("Unable to extract last segment from node"))?
+                .to_str()
+                .ok_or(anyhow!("Unable to convert path segment to a string"))?]
         } else {
             // If the compat flag isn't set, we generate the parts list from the provided shortened
             // pathbuf containing the path within `nodes_path` which preserves literal dots in the

--- a/src/node/nodeinfo.rs
+++ b/src/node/nodeinfo.rs
@@ -88,12 +88,8 @@ impl NodeInfoMeta {
         let namedata = Mapping::from_iter(namedata);
 
         let mut pmeta = Mapping::new();
-        pmeta
-            .insert("environment".into(), self.environment.clone().into())
-            .unwrap();
-        pmeta
-            .insert("name".into(), Value::Mapping(namedata))
-            .unwrap();
+        pmeta.insert("environment".into(), self.environment.clone().into())?;
+        pmeta.insert("name".into(), Value::Mapping(namedata))?;
 
         Ok(pmeta)
     }

--- a/tests/inventory-compose-node-name/classes/cls1.yml
+++ b/tests/inventory-compose-node-name/classes/cls1.yml
@@ -1,0 +1,3 @@
+parameters:
+  foo: foo
+  bar: bar

--- a/tests/inventory-compose-node-name/nodes/_d/d/d2.yml
+++ b/tests/inventory-compose-node-name/nodes/_d/d/d2.yml
@@ -1,0 +1,8 @@
+# compose-node-name treats nodes whose path in `nodes_path` starts with `_`
+# as top-level nodes.
+parameters:
+  node_name: "d2"
+  short_name: "d2"
+  path: "d2"
+  parts: ["d2"]
+  uri_suffix: "_d/d/d2.yml"

--- a/tests/inventory-compose-node-name/nodes/_d/d1.yml
+++ b/tests/inventory-compose-node-name/nodes/_d/d1.yml
@@ -1,0 +1,8 @@
+# compose-node-name treats nodes whose path in `nodes_path` starts with `_`
+# as top-level nodes.
+parameters:
+  node_name: "d1"
+  short_name: "d1"
+  path: "d1"
+  parts: ["d1"]
+  uri_suffix: "_d/d1.yml"

--- a/tests/inventory-compose-node-name/nodes/a.1.yml
+++ b/tests/inventory-compose-node-name/nodes/a.1.yml
@@ -1,3 +1,6 @@
 parameters:
   node_name: a.1
   short_name: "a.1"
+  path: "a.1.yml"
+  parts: ["a.1"]
+  uri_suffix: "nodes/a.1.yml"

--- a/tests/inventory-compose-node-name/nodes/a.1.yml
+++ b/tests/inventory-compose-node-name/nodes/a.1.yml
@@ -1,0 +1,3 @@
+parameters:
+  node_name: a.1
+  short_name: "a.1"

--- a/tests/inventory-compose-node-name/nodes/a.yml
+++ b/tests/inventory-compose-node-name/nodes/a.yml
@@ -1,0 +1,3 @@
+parameters:
+  node_name: a
+  short_name: a

--- a/tests/inventory-compose-node-name/nodes/a.yml
+++ b/tests/inventory-compose-node-name/nodes/a.yml
@@ -1,3 +1,6 @@
 parameters:
   node_name: a
   short_name: a
+  path: "a"
+  parts: ["a"]
+  uri_suffix: "a.yml"

--- a/tests/inventory-compose-node-name/nodes/b/1.yml
+++ b/tests/inventory-compose-node-name/nodes/b/1.yml
@@ -1,0 +1,3 @@
+parameters:
+  node_name: b.1
+  short_name: "1"

--- a/tests/inventory-compose-node-name/nodes/b/1.yml
+++ b/tests/inventory-compose-node-name/nodes/b/1.yml
@@ -1,3 +1,6 @@
 parameters:
   node_name: b.1
   short_name: "1"
+  path: "b/1"
+  parts: ["b", "1"]
+  uri_suffix: "b/1.yml"

--- a/tests/inventory-compose-node-name/nodes/c/1.yml
+++ b/tests/inventory-compose-node-name/nodes/c/1.yml
@@ -1,3 +1,6 @@
 parameters:
   node_name: c.1
   short_name: "1"
+  path: "c/1"
+  parts: ["c", "1"]
+  uri_suffix: "c/1.yml"

--- a/tests/inventory-compose-node-name/nodes/c/1.yml
+++ b/tests/inventory-compose-node-name/nodes/c/1.yml
@@ -1,0 +1,3 @@
+parameters:
+  node_name: c.1
+  short_name: "1"

--- a/tests/inventory-compose-node-name/nodes/c/_c/1.yml
+++ b/tests/inventory-compose-node-name/nodes/c/_c/1.yml
@@ -1,0 +1,6 @@
+parameters:
+  node_name: c._c.1
+  short_name: "1"
+  path: "c/_c/1"
+  parts: ["c", "_c", "1"]
+  uri_suffix: "c/_c/1.yml"

--- a/tests/inventory-compose-node-name/nodes/d.yml
+++ b/tests/inventory-compose-node-name/nodes/d.yml
@@ -1,0 +1,6 @@
+classes:
+  - cls1
+
+parameters:
+  node_name: d
+  short_name: d

--- a/tests/inventory-compose-node-name/nodes/d.yml
+++ b/tests/inventory-compose-node-name/nodes/d.yml
@@ -4,3 +4,6 @@ classes:
 parameters:
   node_name: d
   short_name: d
+  path: "d"
+  parts: ["d"]
+  uri_suffix: "d.yml"

--- a/tests/inventory-compose-node-name/reclass-config-compat.yml
+++ b/tests/inventory-compose-node-name/reclass-config-compat.yml
@@ -1,0 +1,9 @@
+# Add reclass-config.yml for Kapitan/Python reclass
+nodes_uri: nodes
+classes_uri: classes
+compose_node_name: true
+allow_none_override: true
+ignore_class_notfound: true
+reclass_rs_compat_flags: 
+  - compose-node-name-literal-dots
+  - foo

--- a/tests/inventory-compose-node-name/reclass-config.yml
+++ b/tests/inventory-compose-node-name/reclass-config.yml
@@ -1,0 +1,6 @@
+# Add reclass-config.yml for Kapitan/Python reclass
+nodes_uri: nodes
+classes_uri: classes
+compose_node_name: true
+allow_none_override: true
+ignore_class_notfound: true

--- a/tests/test_compose_node_name.py
+++ b/tests/test_compose_node_name.py
@@ -1,0 +1,71 @@
+import reclass_rs
+
+
+def test_no_compose_node_name_compat():
+    r = reclass_rs.Reclass(inventory_path="./tests/inventory-compose-node-name")
+    r.set_compat_flag(reclass_rs.CompatFlag.ComposeNodeNameLiteralDots)
+    assert not r.config.compose_node_name
+    assert r.config.compatflags == {reclass_rs.CompatFlag.ComposeNodeNameLiteralDots}
+
+    inv = r.inventory()
+
+    assert set(inv.nodes.keys()) == {"a.1", "a", "d"}
+
+    a1 = inv.nodes["a.1"].parameters["_reclass_"]["name"]
+    assert a1["full"] == "a.1"
+    assert a1["parts"] == ["a.1"]
+    assert a1["path"] == "a.1"
+    assert a1["short"] == "a.1"
+
+
+def test_no_compose_node_name():
+    r = reclass_rs.Reclass(inventory_path="./tests/inventory-compose-node-name")
+    assert not r.config.compose_node_name
+    assert r.config.compatflags == set()
+
+    inv = r.inventory()
+
+    assert set(inv.nodes.keys()) == {"a.1", "a", "d"}
+
+    a1 = inv.nodes["a.1"].parameters["_reclass_"]["name"]
+    assert a1["full"] == "a.1"
+    assert a1["parts"] == ["a.1"]
+    assert a1["path"] == "a.1"
+    assert a1["short"] == "a.1"
+
+
+def test_compose_node_name_compat():
+    r = reclass_rs.Reclass.from_config(
+        "./tests/inventory-compose-node-name", "reclass-config.yml"
+    )
+    r.set_compat_flag(reclass_rs.CompatFlag.ComposeNodeNameLiteralDots)
+    assert r.config.compose_node_name
+    assert r.config.compatflags == {reclass_rs.CompatFlag.ComposeNodeNameLiteralDots}
+
+    inv = r.inventory()
+
+    assert set(inv.nodes.keys()) == {"a.1", "a", "b.1", "c.1", "d"}
+
+    a1 = inv.nodes["a.1"].parameters["_reclass_"]["name"]
+    assert a1["full"] == "a.1"
+    assert a1["parts"] == ["a", "1"]
+    assert a1["path"] == "a/1"
+    assert a1["short"] == "1"
+
+
+def test_compose_node_name():
+    r = reclass_rs.Reclass.from_config(
+        "./tests/inventory-compose-node-name", "reclass-config.yml"
+    )
+    assert r.config.compose_node_name
+    assert r.config.compatflags == set()
+
+    inv = r.inventory()
+
+    assert set(inv.nodes.keys()) == {"a.1", "a", "b.1", "c.1", "d"}
+
+    a1 = inv.nodes["a.1"].parameters["_reclass_"]["name"]
+    assert a1["full"] == "a.1"
+    assert a1["parts"] == ["a.1"]
+    assert a1["path"] == "a.1"
+    assert a1["short"] == "a.1"

--- a/tests/test_compose_node_name.py
+++ b/tests/test_compose_node_name.py
@@ -44,7 +44,16 @@ def test_compose_node_name_compat():
 
     inv = r.inventory()
 
-    assert set(inv.nodes.keys()) == {"a.1", "a", "b.1", "c.1", "d"}
+    assert set(inv.nodes.keys()) == {
+        "a.1",
+        "a",
+        "b.1",
+        "c.1",
+        "c._c.1",
+        "d",
+        "d1",
+        "d2",
+    }
 
     a1 = inv.nodes["a.1"].parameters["_reclass_"]["name"]
     assert a1["full"] == "a.1"
@@ -62,7 +71,16 @@ def test_compose_node_name():
 
     inv = r.inventory()
 
-    assert set(inv.nodes.keys()) == {"a.1", "a", "b.1", "c.1", "d"}
+    assert set(inv.nodes.keys()) == {
+        "a.1",
+        "a",
+        "b.1",
+        "c.1",
+        "c._c.1",
+        "d",
+        "d1",
+        "d2",
+    }
 
     a1 = inv.nodes["a.1"].parameters["_reclass_"]["name"]
     assert a1["full"] == "a.1"


### PR DESCRIPTION
This PR adds support for the Reclass option `compose-node-name`.

Additionally, we implement support for compatibility flags (including helpers to set/unset/clear flags from Python), and introduce a first flag `ComposeNodeNameLiteralDots`. This flag configures reclass-rs to generate node metadata which matches Python reclass when `compose-node-name` is enabled.

The compatibility flag is required because Python reclass discards literal dots in node filepaths when `compose-node-name` is enabled, resulting in incorrect node metadata for  nodes which have literal dots in their filename (e.g. node `a.1` in the `test/inventory-compose-node-name` inventory).

By default, reclass-rs will preserve literal dots in the node metadata (`path`, and `part`) for node names when `compose-node-name` is enabled.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
