### PR TITLE
Implement getters for `Reclass.nodes` and `Reclass.classes`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,34 @@ impl Reclass {
     pub fn clear_compat_flags(&mut self) {
         self.config.compatflags.clear();
     }
+
+    /// Returns a dict containing all discovered nodes with their paths relative to `nodes_path`.
+    ///
+    /// NOTE: We don't use the generated getter here, because we don't want to return the
+    /// EntityInfo.
+    #[getter]
+    pub fn nodes(&self) -> PyResult<HashMap<String, PathBuf>> {
+        let res = self
+            .nodes
+            .iter()
+            .map(|(k, v)| (k.clone(), v.path.clone()))
+            .collect::<HashMap<String, PathBuf>>();
+        Ok(res)
+    }
+
+    /// Returns the dict of all discovered classes and their paths relative to `classes_path`.
+    ///
+    /// NOTE: We don't use the generated getter here, because we don't want to return the
+    /// EntityInfo.
+    #[getter]
+    pub fn classes(&self) -> PyResult<HashMap<String, PathBuf>> {
+        let res = self
+            .classes
+            .iter()
+            .map(|(k, v)| (k.clone(), v.path.clone()))
+            .collect::<HashMap<String, PathBuf>>();
+        Ok(res)
+    }
 }
 
 impl Default for Reclass {

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -19,6 +19,9 @@ def test_import_new():
     assert pathlib.Path(r.config.classes_path) == invpath / "classes"
     assert r.config.ignore_class_notfound
 
+    assert r.nodes is not None
+    assert r.classes is not None
+
 
 def test_import_raises():
     with pytest.raises(ValueError) as exc:

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -62,7 +62,7 @@ expected_applications = {
     "d": ["n13"],
 }
 
-expected_nodes = set([f"n{i}" for i in range(1, 26)])
+expected_nodes = {f"n{i}" for i in range(1, 26)}
 
 
 def test_inventory():


### PR DESCRIPTION
This allows Python code to read basic information about the results of the node and classes discovery without having to render the inventory.

the new getters return dicts which map the normalized Reclass entity names (with dots for entities in subdirectories) to the file path associated with the entity.
## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
