### PR TITLE
Add support for loading config from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The implementation currently supports the following features of Kapicorp Reclass
 * Nested references
 * References in class names
 * Loading classes with relative names
+* Loading Reclass configuration options from `reclass-config.yaml`
 
 The following Kapicorp Reclass features aren't supported:
 
-* Loading Reclass configuration options from `reclass-config.yaml`
 * Ignoring overwritten missing references
 * Inventory Queries
 * The Reclass option `ignore_class_notfound_regexp`

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -100,14 +100,9 @@ mod inventory_tests {
 
     #[test]
     fn test_render() {
-        let r = Reclass::new(
-            "./tests/inventory",
-            "nodes",
-            "classes",
-            // n18 includes a nonexistent class
-            true,
-        )
-        .unwrap();
+        let mut c = crate::Config::new(Some("./tests/inventory"), None, None, None).unwrap();
+        c.load_from_file("reclass-config.yml").unwrap();
+        let r = Reclass::new_from_config(c).unwrap();
         let inv = Inventory::render(&r).unwrap();
 
         // Check that all nodes are in `inv.nodes`. We do not verify the NodeInfos here, since we

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,16 @@ impl Reclass {
         Ok(r)
     }
 
+    #[classmethod]
+    fn from_config(_cls: &PyType, inventory_path: &str, config_file: &str) -> PyResult<Self> {
+        let mut c = Config::new(Some(inventory_path), None, None, None)
+            .map_err(|e| PyValueError::new_err(format!("{e}")))?;
+        c.load_from_file(config_file)
+            .map_err(|e| PyValueError::new_err(format!("{e}")))?;
+        let r = Self::new_from_config(c).map_err(|e| PyValueError::new_err(format!("{e}")))?;
+        Ok(r)
+    }
+
     fn __repr__(&self) -> String {
         format!("{self:#?}")
     }

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -66,10 +66,7 @@ expected_nodes = set([f"n{i}" for i in range(1, 26)])
 
 
 def test_inventory():
-    r = reclass_rs.Reclass(
-        inventory_path="./tests/inventory",
-        ignore_class_notfound=True,
-    )
+    r = reclass_rs.Reclass.from_config("./tests/inventory", "reclass-config.yml")
     inv = r.inventory()
 
     assert set(inv.nodes.keys()) == expected_nodes


### PR DESCRIPTION
Kapitan allows users to provide additional reclass config options in a file `reclass-config.yml` in the inventory root directory. We add this feature to reclass-rs, but allow users to specify an arbitrary YAML file from which config options are loaded.

Additionally, we update the `inventory_tests::test_render()` Rust and the `test_inventory()` Python test cases to load the config from the already existing `reclass-config.yml` for the test inventory.

This PR is split out from #84 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
