### PR TITLE
Force Cargo to use PyO3 0.20.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.80"
 chrono = "0.4.34"
 indexmap = "2.2.3"
 nom = "7.1.3"
-pyo3 = { version = "0.20.2", features = ["chrono"] }
+pyo3 = { version = "=0.20.2", features = ["chrono"] }
 rayon = "1.8.1"
 regex = "1.10.3"
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
PyO3 0.20.3 breaks building wheels with the default maturin GitHub action.

See also #102 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
