### PR TITLE
Refactor `Reclass` constructor classmethods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,13 +287,26 @@ impl Reclass {
         Ok(r)
     }
 
+    /// Creates a `Reclass` instance for the provided `inventory_path` and loads config options
+    /// from the provided config file. The value of `config_file` is interpreted relative to
+    /// `inventory_path`.
+    ///
+    /// Returns a `Reclass` instance or raises a `ValueError`
     #[classmethod]
-    fn from_config(_cls: &PyType, inventory_path: &str, config_file: &str) -> PyResult<Self> {
+    fn from_config_file(cls: &PyType, inventory_path: &str, config_file: &str) -> PyResult<Self> {
         let mut c = Config::new(Some(inventory_path), None, None, None)
             .map_err(|e| PyValueError::new_err(format!("{e}")))?;
         c.load_from_file(config_file)
             .map_err(|e| PyValueError::new_err(format!("{e}")))?;
-        let r = Self::new_from_config(c).map_err(|e| PyValueError::new_err(format!("{e}")))?;
+        Self::from_config(cls, c)
+    }
+
+    /// Creates a `Reclass` instance from the provided `Config` instance.
+    ///
+    /// Returns a `Reclass` instance or raises a `ValueError`
+    #[classmethod]
+    fn from_config(_cls: &PyType, config: Config) -> PyResult<Self> {
+        let r = Self::new_from_config(config).map_err(|e| PyValueError::new_err(format!("{e}")))?;
         Ok(r)
     }
 

--- a/tests/test_compose_node_name.py
+++ b/tests/test_compose_node_name.py
@@ -35,7 +35,7 @@ def test_no_compose_node_name():
 
 
 def test_compose_node_name_compat():
-    r = reclass_rs.Reclass.from_config(
+    r = reclass_rs.Reclass.from_config_file(
         "./tests/inventory-compose-node-name", "reclass-config.yml"
     )
     r.set_compat_flag(reclass_rs.CompatFlag.ComposeNodeNameLiteralDots)
@@ -63,7 +63,7 @@ def test_compose_node_name_compat():
 
 
 def test_compose_node_name():
-    r = reclass_rs.Reclass.from_config(
+    r = reclass_rs.Reclass.from_config_file(
         "./tests/inventory-compose-node-name", "reclass-config.yml"
     )
     assert r.config.compose_node_name

--- a/tests/test_ignore_class_notfound_regexp.py
+++ b/tests/test_ignore_class_notfound_regexp.py
@@ -4,7 +4,7 @@ import reclass_rs
 
 
 def test_ignore_regexp_render_n1():
-    r = reclass_rs.Reclass.from_config(
+    r = reclass_rs.Reclass.from_config_file(
         "./tests/inventory-class-notfound-regexp", "reclass-config.yml"
     )
     assert r.config.ignore_class_notfound_regexp == ["service\\..*", ".*missing.*"]
@@ -15,7 +15,7 @@ def test_ignore_regexp_render_n1():
 
 
 def test_ignore_regexp_render_n2():
-    r = reclass_rs.Reclass.from_config(
+    r = reclass_rs.Reclass.from_config_file(
         "./tests/inventory-class-notfound-regexp", "reclass-config.yml"
     )
     assert r.config.ignore_class_notfound_regexp == ["service\\..*", ".*missing.*"]
@@ -27,7 +27,7 @@ def test_ignore_regexp_render_n2():
 
 
 def test_ignore_regexp_update_config_render_n2():
-    r = reclass_rs.Reclass.from_config(
+    r = reclass_rs.Reclass.from_config_file(
         "./tests/inventory-class-notfound-regexp", "reclass-config.yml"
     )
     r.set_ignore_class_notfound_regexp([".*"])

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -66,7 +66,7 @@ expected_nodes = {f"n{i}" for i in range(1, 26)}
 
 
 def test_inventory():
-    r = reclass_rs.Reclass.from_config("./tests/inventory", "reclass-config.yml")
+    r = reclass_rs.Reclass.from_config_file("./tests/inventory", "reclass-config.yml")
 
     assert set(r.nodes.keys()) == expected_nodes
     included_classes = set(expected_classes.keys())


### PR DESCRIPTION
This is a breaking change for users that switched to the `Reclass.from_config()` constructor classmethod which was introduced in #92.

This PR renames the existing `Reclass.from_config()` classmethod to `Reclass.from_config_file()` and introduces a new classmethod `Reclass.from_config()` which initializes a `Reclass` instance from an already initialized `Config` instance.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
