### PR TITLE
Add Python classmethod `Config.from_dict()`

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+import reclass_rs
+import pytest
+import pathlib
+
+
+def test_config_from_dict():
+    config_options = {
+        "nodes_uri": "targets",
+        "classes_uri": "classes",
+        "ignore_class_notfound": False,
+        "compose_node_name": False,
+    }
+    c = reclass_rs.Config.from_dict("./tests/inventory", config_options)
+    assert c is not None
+
+    assert not c.ignore_class_notfound
+    assert not c.compose_node_name
+
+    expected_nodes_path = pathlib.Path("./tests/inventory/targets")
+    expected_classes_path = pathlib.Path("./tests/inventory/classes")
+    assert pathlib.Path(c.nodes_path) == expected_nodes_path
+    assert pathlib.Path(c.classes_path) == expected_classes_path
+
+
+def test_config_from_dict_non_default():
+    config_options = {
+        "nodes_uri": "targets",
+        "classes_uri": "classes",
+        "ignore_class_notfound": True,
+        "ignore_class_notfound_regexp": ["foo", "bar"],
+        "compose_node_name": True,
+    }
+    c = reclass_rs.Config.from_dict("./tests/inventory", config_options)
+    assert c is not None
+
+    assert c.ignore_class_notfound
+    assert c.compose_node_name
+
+    expected_nodes_path = pathlib.Path("./tests/inventory/targets")
+    expected_classes_path = pathlib.Path("./tests/inventory/classes")
+    assert pathlib.Path(c.nodes_path) == expected_nodes_path
+    assert pathlib.Path(c.classes_path) == expected_classes_path
+
+    assert c.ignore_class_notfound_regexp == ["foo", "bar"]


### PR DESCRIPTION
This PR introduces classmethod `Config.from_dict()`. The method takes two arguments: the path to the inventory, and a Python dict with config options. The primary usecase for this method will be the Kapitan reclass-rs integration. We need something like this, since Kapitan generates a dict of Reclass options in Python, and we don't provide a clean way to instantiate a `reclass_rs.Reclass` instance from such a dict without this PR.

To avoid a lot of duplication between `Config.from_dict()` and `Config::load_from_file()` we move the setting of known config options into a new private helper function `Config::set_option()`. Additionally, we implement `TryFrom<&PyAny>` for our `Value` type. This conversion method allows us to convert the data in the user-supplied Python dict into `serde_yaml::Value` types for `Config::set_option()`.

Finally, the PR also adds two Python tests which exercise `Config.from_dict()`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->