### PR TITLE
Allow disabling reclass-rs diagnostic messages for unknown config options

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -101,7 +101,7 @@ mod inventory_tests {
     #[test]
     fn test_render() {
         let mut c = crate::Config::new(Some("./tests/inventory"), None, None, None).unwrap();
-        c.load_from_file("reclass-config.yml").unwrap();
+        c.load_from_file("reclass-config.yml", false).unwrap();
         let r = Reclass::new_from_config(c).unwrap();
         let inv = Inventory::render(&r).unwrap();
 
@@ -263,7 +263,8 @@ mod inventory_tests {
             None,
         )
         .unwrap();
-        c.load_from_file("reclass-config-compat.yml").unwrap();
+        c.load_from_file("reclass-config-compat.yml", false)
+            .unwrap();
         let r = Reclass::new_from_config(c).unwrap();
 
         let inv = Inventory::render(&r).unwrap();
@@ -312,7 +313,7 @@ mod inventory_tests {
             None,
         )
         .unwrap();
-        c.load_from_file("reclass-config.yml").unwrap();
+        c.load_from_file("reclass-config.yml", false).unwrap();
         let r = Reclass::new_from_config(c).unwrap();
 
         let inv = Inventory::render(&r).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,10 +293,16 @@ impl Reclass {
     ///
     /// Returns a `Reclass` instance or raises a `ValueError`
     #[classmethod]
-    fn from_config_file(cls: &PyType, inventory_path: &str, config_file: &str) -> PyResult<Self> {
+    #[pyo3(signature = (inventory_path, config_file, verbose=false))]
+    fn from_config_file(
+        cls: &PyType,
+        inventory_path: &str,
+        config_file: &str,
+        verbose: bool,
+    ) -> PyResult<Self> {
         let mut c = Config::new(Some(inventory_path), None, None, None)
             .map_err(|e| PyValueError::new_err(format!("{e}")))?;
-        c.load_from_file(config_file)
+        c.load_from_file(config_file, verbose)
             .map_err(|e| PyValueError::new_err(format!("{e}")))?;
         Self::from_config(cls, c)
     }
@@ -447,7 +453,7 @@ mod tests {
             None,
         )
         .unwrap();
-        c.load_from_file("reclass-config.yml").unwrap();
+        c.load_from_file("reclass-config.yml", true).unwrap();
         let r = Reclass::new_from_config(c).unwrap();
         assert_eq!(r.nodes.len(), 8);
         let mut nodes = r.nodes.keys().collect::<Vec<_>>();

--- a/src/node/node_render_tests_ignore_class_notfound_regexp.rs
+++ b/src/node/node_render_tests_ignore_class_notfound_regexp.rs
@@ -10,7 +10,7 @@ fn test_render_n1() {
         None,
     )
     .unwrap();
-    c.load_from_file("reclass-config.yml").unwrap();
+    c.load_from_file("reclass-config.yml", false).unwrap();
     let r = Reclass::new_from_config(c).unwrap();
 
     let n1 = r.render_node("n1").unwrap();
@@ -33,7 +33,7 @@ fn test_render_n2() {
         None,
     )
     .unwrap();
-    c.load_from_file("reclass-config.yml").unwrap();
+    c.load_from_file("reclass-config.yml", false).unwrap();
     let r = Reclass::new_from_config(c).unwrap();
 
     let n2 = r.render_node("n2");


### PR DESCRIPTION
We introduce a new optional boolean parameter `verbose` which controls whether diagnostic messages for unknown config options are printed for the Python classmethods `Config.from_dict()` and `Reclass.from_config_file()`.

This parameter is passed to `Config::load_from_file()` and `Config::set_option()`. Since the new parameter isn't optional for either of these methods, this change is breaking for Rust clients that use `Config::load_from_file()`.

If Python callers don't provide the new optional parameter, it defaults to `false` which disables the diagnostic messages.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
