### PR TITLE
Fix node discovery when compose-node-name is disabled

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -352,4 +352,114 @@ mod inventory_tests {
             Some(&sequence(&["a.1"]))
         );
     }
+
+    #[test]
+    fn test_render_nested_nodes() {
+        let mut c =
+            crate::Config::new(Some("./tests/inventory-nested-nodes"), None, None, None).unwrap();
+        c.compose_node_name = false;
+        let r = Reclass::new_from_config(c).unwrap();
+
+        let inv = Inventory::render(&r).unwrap();
+
+        let invabsdir = std::fs::canonicalize("./tests/inventory-nested-nodes").unwrap();
+        let invabsdir = invabsdir.to_str().unwrap();
+
+        let mut nodes = inv.nodes.keys().collect::<Vec<_>>();
+        nodes.sort();
+        assert_eq!(nodes, vec!["a1", "b1", "c1", "d1"]);
+
+        for n in nodes {
+            let node = &inv.nodes[n];
+            assert_eq!(node.reclass.node, *n);
+            assert_eq!(node.reclass.name, *n);
+            let expected = node.parameters.get(&"nested".into()).unwrap();
+            let expected_full_name = expected.get(&"node_name".into()).unwrap();
+            let expected_short_name = expected.get(&"short_name".into()).unwrap();
+            let expected_path = expected.get(&"path".into()).unwrap();
+            let expected_parts = expected.get(&"parts".into()).unwrap();
+            let expected_uri_suffix = expected.get(&"uri_suffix".into()).unwrap();
+            assert_eq!(
+                node.reclass.uri,
+                format!(
+                    "yaml_fs://{invabsdir}/nodes/{}",
+                    expected_uri_suffix.as_str().unwrap()
+                )
+            );
+            let params_reclass_name = node
+                .parameters
+                .get(&"_reclass_".into())
+                .unwrap()
+                .get(&"name".into())
+                .unwrap();
+            assert_eq!(
+                params_reclass_name.get(&"full".into()),
+                Some(expected_full_name)
+            );
+            assert_eq!(
+                params_reclass_name.get(&"short".into()),
+                Some(expected_short_name)
+            );
+            assert_eq!(params_reclass_name.get(&"path".into()), Some(expected_path));
+            assert_eq!(
+                params_reclass_name.get(&"parts".into()),
+                Some(expected_parts)
+            )
+        }
+    }
+
+    #[test]
+    fn test_render_nested_nodes_composed() {
+        let mut c =
+            crate::Config::new(Some("./tests/inventory-nested-nodes"), None, None, None).unwrap();
+        c.compose_node_name = true;
+        let r = Reclass::new_from_config(c).unwrap();
+
+        let inv = Inventory::render(&r).unwrap();
+
+        let invabsdir = std::fs::canonicalize("./tests/inventory-nested-nodes").unwrap();
+        let invabsdir = invabsdir.to_str().unwrap();
+
+        let mut nodes = inv.nodes.keys().collect::<Vec<_>>();
+        nodes.sort();
+        assert_eq!(nodes, vec!["a.a1", "b.b1", "c.c1", "d1"]);
+
+        for n in nodes {
+            let node = &inv.nodes[n];
+            assert_eq!(node.reclass.node, *n);
+            assert_eq!(node.reclass.name, *n);
+            let expected = node.parameters.get(&"composed".into()).unwrap();
+            let expected_full_name = expected.get(&"node_name".into()).unwrap();
+            let expected_short_name = expected.get(&"short_name".into()).unwrap();
+            let expected_path = expected.get(&"path".into()).unwrap();
+            let expected_parts = expected.get(&"parts".into()).unwrap();
+            let expected_uri_suffix = expected.get(&"uri_suffix".into()).unwrap();
+            assert_eq!(
+                node.reclass.uri,
+                format!(
+                    "yaml_fs://{invabsdir}/nodes/{}",
+                    expected_uri_suffix.as_str().unwrap()
+                )
+            );
+            let params_reclass_name = node
+                .parameters
+                .get(&"_reclass_".into())
+                .unwrap()
+                .get(&"name".into())
+                .unwrap();
+            assert_eq!(
+                params_reclass_name.get(&"full".into()),
+                Some(expected_full_name)
+            );
+            assert_eq!(
+                params_reclass_name.get(&"short".into()),
+                Some(expected_short_name)
+            );
+            assert_eq!(params_reclass_name.get(&"path".into()), Some(expected_path));
+            assert_eq!(
+                params_reclass_name.get(&"parts".into()),
+                Some(expected_parts)
+            )
+        }
+    }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -48,7 +48,13 @@ impl Node {
         let ncontents = std::fs::read_to_string(invpath.canonicalize()?)?;
 
         let uri = format!("yaml_fs://{}", to_lexical_absolute(&invpath)?.display());
-        let meta = NodeInfoMeta::new(name, name, &uri, nodeinfo.path.with_extension(""), "base");
+        // NOTE(sg): parts is only the name when compose-node-name isn't enabled
+        let meta_parts = if r.config.compose_node_name {
+            nodeinfo.path.with_extension("")
+        } else {
+            PathBuf::from(name)
+        };
+        let meta = NodeInfoMeta::new(name, name, &uri, meta_parts, "base");
         Node::from_str(meta, None, &ncontents)
     }
 

--- a/tests/inventory-nested-nodes/classes/cls1.yml
+++ b/tests/inventory-nested-nodes/classes/cls1.yml
@@ -1,0 +1,3 @@
+parameters:
+  foo: foo
+  bar: bar

--- a/tests/inventory-nested-nodes/nodes/_d/d1.yml
+++ b/tests/inventory-nested-nodes/nodes/_d/d1.yml
@@ -1,0 +1,15 @@
+# compose-node-name treats nodes whose path in `nodes_path` starts with `_`
+# as top-level nodes.
+parameters:
+  composed:
+    node_name: d1
+    short_name: d1
+    path: d1
+    parts: ["d1"]
+    uri_suffix: _d/d1.yml
+  nested:
+    node_name: d1
+    short_name: d1
+    path: d1
+    parts: [d1]
+    uri_suffix: _d/d1.yml

--- a/tests/inventory-nested-nodes/nodes/a/a1.yml
+++ b/tests/inventory-nested-nodes/nodes/a/a1.yml
@@ -1,0 +1,13 @@
+parameters:
+  composed:
+    node_name: a.a1
+    short_name: a1
+    path: a/a1
+    parts: ["a", "a1"]
+    uri_suffix: a/a1.yml
+  nested:
+    node_name: a1
+    short_name: a1
+    path: a1
+    parts: ["a1"]
+    uri_suffix: a/a1.yml

--- a/tests/inventory-nested-nodes/nodes/b/b1.yml
+++ b/tests/inventory-nested-nodes/nodes/b/b1.yml
@@ -1,0 +1,13 @@
+parameters:
+  composed:
+    node_name: b.b1
+    short_name: b1
+    path: b/b1
+    parts: ["b", "b1"]
+    uri_suffix: b/b1.yml
+  nested:
+    node_name: b1
+    short_name: b1
+    path: b1
+    parts: ["b1"]
+    uri_suffix: b/b1.yml

--- a/tests/inventory-nested-nodes/nodes/c/c1.yml
+++ b/tests/inventory-nested-nodes/nodes/c/c1.yml
@@ -1,0 +1,13 @@
+parameters:
+  composed:
+    node_name: c.c1
+    short_name: c1
+    path: c/c1
+    parts: ["c", "c1"]
+    uri_suffix: c/c1.yml
+  nested:
+    node_name: c1
+    short_name: c1
+    path: c1
+    parts: ["c1"]
+    uri_suffix: c/c1.yml

--- a/tests/test_compose_node_name.py
+++ b/tests/test_compose_node_name.py
@@ -1,37 +1,50 @@
+import pytest
 import reclass_rs
 
 
+def test_no_compose_node_name_compat_collision():
+    config = reclass_rs.Config.from_dict(
+        inventory_path="./tests/inventory-compose-node-name",
+        config={"reclass_rs_compat_flags": ["compose-node-name-literal-dots"]},
+    )
+    assert config.compatflags == {reclass_rs.CompatFlag.ComposeNodeNameLiteralDots}
+    with pytest.raises(ValueError) as exc:
+        r = reclass_rs.Reclass.from_config(config)
+
+    assert "Error while discovering nodes: Definition of node '1'" in str(exc)
+
+
 def test_no_compose_node_name_compat():
-    r = reclass_rs.Reclass(inventory_path="./tests/inventory-compose-node-name")
+    r = reclass_rs.Reclass(inventory_path="./tests/inventory-nested-nodes")
     r.set_compat_flag(reclass_rs.CompatFlag.ComposeNodeNameLiteralDots)
     assert not r.config.compose_node_name
     assert r.config.compatflags == {reclass_rs.CompatFlag.ComposeNodeNameLiteralDots}
 
     inv = r.inventory()
 
-    assert set(inv.nodes.keys()) == {"a.1", "a", "d"}
+    assert set(inv.nodes.keys()) == {"a1", "b1", "c1", "d1"}
 
-    a1 = inv.nodes["a.1"].parameters["_reclass_"]["name"]
-    assert a1["full"] == "a.1"
-    assert a1["parts"] == ["a.1"]
-    assert a1["path"] == "a.1"
-    assert a1["short"] == "a.1"
+    a1 = inv.nodes["a1"].parameters["_reclass_"]["name"]
+    assert a1["full"] == "a1"
+    assert a1["parts"] == ["a1"]
+    assert a1["path"] == "a1"
+    assert a1["short"] == "a1"
 
 
 def test_no_compose_node_name():
-    r = reclass_rs.Reclass(inventory_path="./tests/inventory-compose-node-name")
+    r = reclass_rs.Reclass(inventory_path="./tests/inventory-nested-nodes")
     assert not r.config.compose_node_name
     assert r.config.compatflags == set()
 
     inv = r.inventory()
 
-    assert set(inv.nodes.keys()) == {"a.1", "a", "d"}
+    assert set(inv.nodes.keys()) == {"a1", "b1", "c1", "d1"}
 
-    a1 = inv.nodes["a.1"].parameters["_reclass_"]["name"]
-    assert a1["full"] == "a.1"
-    assert a1["parts"] == ["a.1"]
-    assert a1["path"] == "a.1"
-    assert a1["short"] == "a.1"
+    a1 = inv.nodes["a1"].parameters["_reclass_"]["name"]
+    assert a1["full"] == "a1"
+    assert a1["parts"] == ["a1"]
+    assert a1["path"] == "a1"
+    assert a1["short"] == "a1"
 
 
 def test_compose_node_name_compat():


### PR DESCRIPTION
Python reclass will still discover nested nodes if compose-node-name is disabled, but will strip the prefix path from the resulting node names (and the `parts` metadata).

This commit adjusts reclass-rs to behave identically to Python reclass for inventories which contain nodes in subfolders of `inventory/nodes` when compose-node-name isn't enabled.

Fixes #148

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
