### PR TITLE
Update Python GH workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,4 +1,4 @@
-# This file is adapted from the generated workflow from maturin v1.5.0
+# This file is adapted from the generated workflow from maturin v1.8.1
 # To update, run
 #
 #    maturin generate-ci --pytest github
@@ -33,16 +33,28 @@ jobs:
           echo "version=$(git describe --tags --always --match=v* | sed 's/^v//' | cut -d- -f1,2)" >> "$GITHUB_OUTPUT"
 
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     needs: get-version
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        platform:
+          - runner: ubuntu-24.04
+            target: x86_64
+          - runner: ubuntu-24.04
+            target: x86
+          - runner: ubuntu-24.04
+            target: aarch64
+          - runner: ubuntu-24.04
+            target: armv7
+          - runner: ubuntu-24.04
+            target: s390x
+          - runner: ubuntu-24.04
+            target: ppc64le
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: 3.x
       - uses: taiki-e/cache-cargo-install-action@v2
         with:
           tool: cargo-edit
@@ -54,28 +66,30 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.target }}
+          target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.target }}
+          name: wheels-linux-${{ matrix.platform.target }}
           path: dist
       - name: pytest
-        if: ${{ startsWith(matrix.target, 'x86_64') }}
+        if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
         shell: bash
         run: |
           set -e
+          python3 -m venv .venv
+          source .venv/bin/activate
           pip install reclass-rs --find-links dist --force-reinstall
           pip install pytest
           pytest
       - name: pytest
-        if: ${{ !startsWith(matrix.target, 'x86') && matrix.target != 'ppc64' }}
-        uses: uraimo/run-on-arch-action@v2.8.1
+        if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' }}
+        uses: uraimo/run-on-arch-action@v2
         with:
-          arch: ${{ matrix.target }}
+          arch: ${{ matrix.platform.target }}
           distro: ubuntu22.04
           githubToken: ${{ github.token }}
           install: |
@@ -87,57 +101,25 @@ jobs:
             pip3 install reclass-rs --find-links dist --force-reinstall
             pytest
 
-  windows:
-    runs-on: windows-latest
+  musllinux:
+    runs-on: ${{ matrix.platform.runner }}
     needs: get-version
     strategy:
       matrix:
-        target: [x64, x86]
+        platform:
+          - runner: ubuntu-24.04
+            target: x86_64
+          - runner: ubuntu-24.04
+            target: x86
+          - runner: ubuntu-24.04
+            target: aarch64
+          - runner: ubuntu-24.04
+            target: armv7
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-          architecture: ${{ matrix.target }}
-      - uses: taiki-e/cache-cargo-install-action@v2
-        with:
-          tool: cargo-edit
-      - name: Set package version
-        env:
-          VERSION: ${{ needs.get-version.outputs.version }}
-        run: |
-          cargo set-version "$env:VERSION"
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
-          sccache: 'true'
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows-${{ matrix.target }}
-          path: dist
-      - name: pytest
-        if: ${{ !startsWith(matrix.target, 'aarch64') }}
-        shell: bash
-        run: |
-          set -e
-          pip install reclass-rs --find-links dist --force-reinstall
-          pip install pytest
-          pytest
-
-  macos:
-    runs-on: macos-latest
-    needs: get-version
-    strategy:
-      matrix:
-        target: [x86_64, aarch64]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+          python-version: 3.x
       - uses: taiki-e/cache-cargo-install-action@v2
         with:
           tool: cargo-edit
@@ -149,19 +131,131 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.target }}
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+          manylinux: musllinux_1_2
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-musllinux-${{ matrix.platform.target }}
+          path: dist
+      - name: pytest
+        if: ${{ startsWith(matrix.platform.target, 'x86_64') }}
+        uses: addnab/docker-run-action@v3
+        with:
+          image: alpine:latest
+          options: -v ${{ github.workspace }}:/io -w /io
+          run: |
+            set -e
+            apk add py3-pip py3-virtualenv
+            python3 -m virtualenv .venv
+            source .venv/bin/activate
+            pip install reclass-rs --no-index --find-links dist --force-reinstall
+            pip install pytest
+            pytest
+      - name: pytest
+        if: ${{ !startsWith(matrix.platform.target, 'x86') }}
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: ${{ matrix.platform.target }}
+          distro: alpine_latest
+          githubToken: ${{ github.token }}
+          install: |
+            apk add py3-virtualenv
+          run: |
+            set -e
+            python3 -m virtualenv .venv
+            source .venv/bin/activate
+            pip install pytest
+            pip install reclass-rs --find-links dist --force-reinstall
+            pytest
+
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    needs: get-version
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+          - runner: windows-latest
+            target: x86
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          architecture: ${{ matrix.platform.target }}
+      - uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-edit
+      - name: Set package version
+        env:
+          VERSION: ${{ needs.get-version.outputs.version }}
+        run: |
+          cargo set-version "$env:VERSION"
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.target }}
+          name: wheels-windows-${{ matrix.platform.target }}
           path: dist
       - name: pytest
-        if: ${{ !startsWith(matrix.target, 'aarch64') }}
+        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
         run: |
           set -e
+          python3 -m venv .venv
+          source .venv/Scripts/activate
+          pip install reclass-rs --find-links dist --force-reinstall
+          pip install pytest
+          pytest
+
+  macos:
+    runs-on: ${{ matrix.platform.runner }}
+    needs: get-version
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-13
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-edit
+      - name: Set package version
+        env:
+          VERSION: ${{ needs.get-version.outputs.version }}
+        run: |
+          cargo set-version "${VERSION}"
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          sccache: 'true'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: dist
+      - name: pytest
+        run: |
+          set -e
+          python3 -m venv .venv
+          source .venv/bin/activate
           pip install reclass-rs --find-links dist --force-reinstall
           pip install pytest
           pytest
@@ -194,7 +288,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/v')"
-    needs: [linux, windows, macos, sdist]
+    needs: [linux, musllinux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4
       - name: Publish to PyPI


### PR DESCRIPTION
Update our customized workflow to match the workflow generated by maturin 1.8.1.

Extracted from #149, where we noticed that the macOS x86_64 tests didn't use the locally built wheel anymore.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
