### PR TITLE
Add missing context to errors that occur while flattening values

### DIFF
--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -104,6 +104,11 @@ impl ResolveState {
             "While looking up key '{key}' in reference '{r}' for parameter '{current_key}': {msg}"
         )
     }
+
+    pub(crate) fn render_flattening_error(&self, msg: &str) -> anyhow::Error {
+        let current_key = self.current_key();
+        anyhow!("In {current_key}: {msg}")
+    }
 }
 
 /// Maximum allowed recursion depth for Token::resolve(). We're fairly conservative with the value,
@@ -348,7 +353,7 @@ fn interpolate_string_or_valuelist(
                 i.push(v);
             }
             // Finally we flatten the resulting ValueList into a single Value.
-            Value::ValueList(i).flattened()
+            Value::ValueList(i).flattened(state)
         }
         // Do nothing for other types
         _ => Ok(v.clone()),

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -405,13 +405,13 @@ impl Mapping {
     ///
     /// Used in `Value::flattened()` to preserve const and override key information when flattening
     /// Mapping values.
-    pub(super) fn flattened(&self) -> Result<Self> {
+    pub(super) fn flattened(&self, state: &mut ResolveState) -> Result<Self> {
         let mut res = Self::new();
         for (k, v) in self {
             // Propagate key properties to the resulting mapping by using `insert_impl()`.
             res.insert_impl(
                 k.clone(),
-                v.flattened()?,
+                v.flattened(state)?,
                 self.is_const(k),
                 self.is_override(k),
             )?;
@@ -436,7 +436,7 @@ impl Mapping {
             let mut st = state.clone();
             st.push_mapping_key(k)?;
             let mut v = v.interpolate(root, &mut st)?;
-            v.flatten()?;
+            v.flatten(&mut st)?;
             // Propagate key properties to the resulting mapping by using `insert_impl()`.
             res.insert_impl(k.clone(), v, self.is_const(k), self.is_override(k))?;
         }


### PR DESCRIPTION
We pass the existing `ResolveState` to the flattening step (where we merge layers of values into a single value), so we get some context information when an error happens in the flattening and merging process (e.g. because a Mapping is being merged over a string literal)

Previously, such an error would have no context, e.g.

```
Error rendering node <node>: While resolving references: Can't merge Value::Mapping over Value::Literal
```

With this change, the error now indicates in which parameter field it occurred:

```
Error rendering node <node>: While resolving references: In <path.to.field>: Can't merge Value::Mapping over Value::Literal
```

Follow-up to #69 
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
