### PR TITLE
Add missing `classes` in `NodeInfo::as_dict()`

### DIFF
--- a/src/node/nodeinfo.rs
+++ b/src/node/nodeinfo.rs
@@ -180,7 +180,7 @@ impl NodeInfo {
         let dict = PyDict::new(py);
         dict.set_item("__reclass__", self.reclass_as_dict(py)?)?;
         dict.set_item("applications", self.applications.clone().into_pyobject(py)?)?;
-        dict.set_item("applications", self.applications.clone().into_pyobject(py)?)?;
+        dict.set_item("classes", self.classes.clone().into_pyobject(py)?)?;
         dict.set_item(
             "environment",
             self.reclass.environment.clone().into_pyobject(py)?,

--- a/tests/test_nodeinfo.py
+++ b/tests/test_nodeinfo.py
@@ -25,6 +25,28 @@ def test_nodeinfo_n1():
     }
 
 
+def test_nodeinfo_n1_as_dict():
+    r = reclass_rs.Reclass(inventory_path="./tests/inventory")
+    n = r.nodeinfo("n1").as_dict()
+    npath = Path("./tests/inventory/nodes/n1.yml").resolve()
+    assert n["__reclass__"]["uri"] == f"yaml_fs://{npath}"
+    assert n["applications"] == ["app1", "app2"]
+    assert n["classes"] == ["cls1", "cls2"]
+    assert n["parameters"] == {
+        "_reclass_": {
+            "environment": "base",
+            "name": {
+                "full": "n1",
+                "parts": ["n1"],
+                "path": "n1",
+                "short": "n1",
+            },
+        },
+        "foo": {"foo": "foo", "bar": "cls2", "baz": "cls1"},
+        "bar": {"foo": "foo"},
+    }
+
+
 def test_nodeinfo_n1_no_invpath():
     r = reclass_rs.Reclass(
         nodes_path="./tests/inventory/nodes", classes_path="./tests/inventory/classes"


### PR DESCRIPTION
This fixes a copy-paste error which set `applications` twice and `classes` not at all.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
