### PR TITLE
Fix initialization for `ignore_class_notfound_regexp` in `Config::from_dict()`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -305,6 +305,11 @@ impl Config {
                     PyValueError::new_err(format!("Error while setting option {kstr}: {e}"))
                 })?;
         }
+        cfg.compile_ignore_class_notfound_patterns().map_err(|e| {
+            PyValueError::new_err(format!(
+                "Error while compiling class_notfound_regexp patterns: {e}"
+            ))
+        })?;
 
         Ok(cfg)
     }

--- a/tests/test_ignore_class_notfound_regexp.py
+++ b/tests/test_ignore_class_notfound_regexp.py
@@ -35,3 +35,24 @@ def test_ignore_regexp_update_config_render_n2():
 
     n2 = r.nodeinfo("n2")
     assert n2 is not None
+
+
+def test_ignore_regexp_from_dict():
+    config_options = {
+        "nodes_uri": "nodes",
+        "classes_uri": "classes",
+        "ignore_class_notfound": True,
+        "ignore_class_notfound_regexp": ["service\\..*", ".*missing.*"],
+    }
+    c = reclass_rs.Config.from_dict(
+        "./tests/inventory-class-notfound-regexp", config_options
+    )
+    r = reclass_rs.Reclass.from_config(c)
+
+    n1 = r.nodeinfo("n1")
+    assert n1 is not None
+
+    with pytest.raises(
+        ValueError, match="Error while rendering n2: Class foo not found"
+    ):
+        n2 = r.nodeinfo("n2")


### PR DESCRIPTION
We need to call `Config::compile_ignore_class_notfound_patterns` in `Config::from_dict()` to ensure that regex patterns which are provided via Python dict are correctly initialized.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
