### PR TITLE
Add Python tests which compare against kapicorp-reclass

### DIFF
--- a/tests/test_inventory_class_mapping.py
+++ b/tests/test_inventory_class_mapping.py
@@ -28,6 +28,9 @@ def test_inventory_class_mappings(compose_node_name, class_mappings_match_path):
             "test.*           composed.test",
             "production.*     composed.production",
             "/(test|production)\\/.*/ regex.params regex.\\\\1",
+            "/^test(?!.*-stg-test).*/  cluster.test",
+            "/^test.*-stg-test.*/      cluster.staging",
+            "/.*c$/                    class1 class2",
         ],
         "class_mappings_match_path": False,
     }

--- a/tests/test_inventory_class_mapping.py
+++ b/tests/test_inventory_class_mapping.py
@@ -2,6 +2,8 @@ import reclass_rs
 import pytest
 import sys
 
+from test_with_kapicorp_reclass import prune_timestamps, py_reclass_inventory
+
 
 @pytest.mark.parametrize(
     "compose_node_name,class_mappings_match_path",
@@ -37,35 +39,8 @@ def test_inventory_class_mappings(compose_node_name, class_mappings_match_path):
 
     inv = r.inventory().as_dict()
     assert inv is not None
+    prune_timestamps(inv)
 
-    # delete timestamps from resulting dict to ensure that we don't run into issues when comparing
-    # two dicts that are rendered at slightly different times
-    del inv["__reclass__"]["timestamp"]
-    for n in inv["nodes"].keys():
-        del inv["nodes"][n]["__reclass__"]["timestamp"]
-
-    storage = reclass.get_storage(
-        "yaml_fs",
-        "./tests/inventory-class-mapping/nodes",
-        "./tests/inventory-class-mapping/classes",
-        config_options["compose_node_name"],
-    )
-    class_mappings = config_options.get("class_mappings")
-    _reclass = reclass.core.Core(
-        storage, class_mappings, reclass.settings.Settings(config_options)
-    )
-    py_inv = _reclass.inventory()
-
-    # delete timestamps from resulting dict to ensure that we don't run into issues when comparing
-    # two dicts that are rendered at slightly different times
-    del py_inv["__reclass__"]["timestamp"]
-    for n in py_inv["nodes"].keys():
-        del py_inv["nodes"][n]["__reclass__"]["timestamp"]
-
-    for nodes in py_inv["classes"].values():
-        nodes.sort()
-
-    for nodes in py_inv["applications"].values():
-        nodes.sort()
+    py_inv = py_reclass_inventory("./tests/inventory-class-mapping", config_options)
 
     assert inv == py_inv

--- a/tests/test_with_kapicorp_reclass.py
+++ b/tests/test_with_kapicorp_reclass.py
@@ -1,0 +1,135 @@
+import reclass_rs
+import pytest
+import sys
+
+
+def fixup_pyfmt(v: str) -> str:
+    # NOTE(sg): this is not generally applicable, it only works for the `embedded` parameter for
+    # node n22 in `tests/inventory`.
+    r = v.replace("'", '"')
+    lines = r.splitlines()
+    for i in range(0, len(lines)):
+        parts = lines[i].split(": ", 1)
+        parts[1] = parts[1].replace(" ", "")
+        lines[i] = ": ".join(parts)
+
+    return "\n".join(lines)
+
+
+def prune_timestamps(inv: dict):
+    del inv["__reclass__"]["timestamp"]
+    for n in inv["nodes"].values():
+        del n["__reclass__"]["timestamp"]
+
+
+def py_reclass_inventory(inv_path: str, config: dict) -> dict:
+    import reclass
+    import reclass.core
+
+    storage = reclass.get_storage(
+        "yaml_fs",
+        f"{inv_path}/nodes",
+        f"{inv_path}/classes",
+        config["compose_node_name"],
+    )
+    class_mappings = config.get("class_mappings")
+    _reclass = reclass.core.Core(
+        storage, class_mappings, reclass.settings.Settings(config)
+    )
+    py_inv = _reclass.inventory()
+    # remove timestamps so we can compare the whole dicts
+    prune_timestamps(py_inv)
+
+    # ensure that kapicorp-reclass top-level `classes` and `applications` values are sorted lists
+    for nodes in py_inv["classes"].values():
+        nodes.sort()
+    for nodes in py_inv["applications"].values():
+        nodes.sort()
+
+    return py_inv
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="kapicorp-reclass not supported on Windows"
+)
+def test_inventory_matches_pyreclass():
+    config_options = {
+        "compose_node_name": False,
+        "allow_none_override": True,
+        "ignore_class_notfound": True,
+    }
+    c = reclass_rs.Config.from_dict("./tests/inventory", config_options)
+    assert c is not None
+    r = reclass_rs.Reclass.from_config(c)
+    assert r is not None
+
+    inv = r.inventory().as_dict()
+    assert inv is not None
+    prune_timestamps(inv)
+
+    py_inv = py_reclass_inventory("./tests/inventory", config_options)
+    # kapicorp-reclass hasn't fixed the applications merge bug yet,
+    # cf.https://github.com/kapicorp/reclass/pull/9
+    py_inv["nodes"]["n12"]["applications"].remove("b")
+    py_inv["applications"]["b"].remove("n12")
+
+    # complex values that are embedded in a string via reclass reference are formatted differently,
+    # we use proper JSON serialization, while kapicorp-reclass just uses Python object notation
+    # (via string formatting for the value).
+    for k, v in py_inv["nodes"]["n22"]["parameters"]["embedded"].items():
+        py_inv["nodes"]["n22"]["parameters"]["embedded"][k] = fixup_pyfmt(v)
+
+    assert inv == py_inv
+
+
+@pytest.mark.parametrize("compose", [False, True])
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="kapicorp-reclass not supported on Windows"
+)
+def test_inventory_nested_nodes_matches_pyreclass(compose):
+    config_options = {
+        "compose_node_name": compose,
+        "allow_none_override": True,
+        "ignore_class_notfound": True,
+    }
+    c = reclass_rs.Config.from_dict("./tests/inventory-nested-nodes", config_options)
+    assert c is not None
+    r = reclass_rs.Reclass.from_config(c)
+    assert r is not None
+
+    inv = r.inventory().as_dict()
+    assert inv is not None
+    prune_timestamps(inv)
+
+    py_inv = py_reclass_inventory("./tests/inventory-nested-nodes", config_options)
+
+    assert inv == py_inv
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="kapicorp-reclass not supported on Windows"
+)
+def test_inventory_compose_node_name_compat_matches_pyreclass():
+    config_options = {
+        "compose_node_name": True,
+        "allow_none_override": True,
+        "ignore_class_notfound": True,
+        # NOTE(sg): We need the compose-node-name-literal-dots Python reclass compatibility mode
+        # here, since the `compose-node-name` inventory has nodes that behave differently without
+        # the compatibility mode.
+        "reclass_rs_compat_flags": ["compose-node-name-literal-dots"],
+    }
+    c = reclass_rs.Config.from_dict(
+        "./tests/inventory-compose-node-name", config_options
+    )
+    assert c is not None
+    r = reclass_rs.Reclass.from_config(c)
+    assert r is not None
+
+    inv = r.inventory().as_dict()
+    assert inv is not None
+    prune_timestamps(inv)
+
+    py_inv = py_reclass_inventory("./tests/inventory-compose-node-name", config_options)
+
+    assert inv == py_inv


### PR DESCRIPTION
We already use this approach for the `class_mappings` feature (cf. #160). This PR adds additional Python tests which compare the output of kapicorp-reclass with reclass-rs.

Note that we currently don't have a comparison test for `tests/inventory-class-notfound-regexp` since that inventory doesn't actually render fully.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
