### PR TITLE
Update release action to not use deprecated `::set-output`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,22 +29,24 @@ jobs:
           git fetch origin +refs/tags/*:refs/tags/*
           # Extract tag message
           TAG_MSG=$(git tag -n --format='%(contents:body)' ${GITHUB_REF##refs/tags/} | tr -d '\r')
-          # Escape literal % and newlines (\n, \r) for github actions output
-          TAG_MSG=${TAG_MSG//'%'/%25}
-          TAG_MSG=${TAG_MSG//$'\n'/%0A}
           # Join multiple lines belonging to the same paragraph for GitHub
           # markdown.
-          # Paragraph breaks should be %0A%0A. We replace single line breaks
-          # with a space with sed.
-          TAG_MSG=$(echo ${TAG_MSG} |sed 's/\([^A]\)%0A\([^%]\)/\1 \2/g')
-          # Set action output `messsage`
-          echo "::set-output name=message::${TAG_MSG}"
+          # Paragraph breaks should be '\n\n'. List items should be '\n*'. We
+          # replace single line breaks which don't preceed a '*' with a space
+          # with sed. Note `sed -z` operates on the whole input instead of
+          # line-wise. Note that this currently still breaks markdown code
+          # blocks.
+          TAG_MSG=$(echo "$TAG_MSG" | sed -z 's/\([^\n]\)\n\([^\n\*]\)/\1 \2/g')
+          # Set action output `messsage` as JSON-encoded string to preserve
+          # newlines. We decode with `fromJSON()` below.
+          TAG_MSG=$(jq -n --arg msg "${TAG_MSG}" '$msg')
+          echo "message=${TAG_MSG}" >> $GITHUB_OUTPUT
         env:
           GITHUB_REF: ${{ github.ref }}
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
-          body: "# Summary\n\n${{steps.tag_message.outputs.message}}\n\n# Changes\n\n${{steps.build_changelog.outputs.changelog}}"
+          body: "# Summary\n\n${{fromJSON(steps.tag_message.outputs.message)}}\n\n# Changes\n\n${{steps.build_changelog.outputs.changelog}}"
           prerelease: "${{ contains(github.ref, '-rc') }}"
           # Ensure target branch for release is "main"
           commit: main


### PR DESCRIPTION
We also need to adjust how we pass the release summary that we read from the Git tag to `ncipollo/release-action`: when passing step outputs via `$GITHUB_OUTPUT` we no longer need to escape newlines with `%0A`, but instead we need to encode the whole message as JSON to preserve newlines.

We then apply the GitHub actions builtin `fromJSON()` to decode the message when passing it to `ncipollo/release-action` for the release body.

Note that the updated `sed` expression now directly operates on newlines, and also preserves list items as long as the list item's '*' is directly at the start of the line.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
