### PR TITLE
Add explicit inferred lifetimes for Rust 1.89

### DIFF
--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -392,7 +392,7 @@ impl std::fmt::Display for ParseError<'_> {
 ///
 /// Users should use `Token::parse()` which converts the internal `ParseError` into a format
 /// suitable to be handled with `anyhow::Result`.
-fn parse_ref(input: &str) -> Result<Token, ParseError> {
+fn parse_ref(input: &str) -> Result<Token, ParseError<'_>> {
     use self::parser::parse_ref;
     let (uncons, token) = parse_ref(input).map_err(|e| match e {
         nom::Err::Error(e) | nom::Err::Failure(e) => ParseError {

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -230,7 +230,7 @@ impl Mapping {
     /// insertion. Iterator element type is `(&'a Value, &'a Value)`.
     #[inline]
     #[must_use]
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter {
             iter: self.map.iter(),
         }
@@ -270,7 +270,7 @@ impl Mapping {
     /// Returns the given key's entry in the map for insertion and/or in-place updates.
     /// Returns an error if called for a key which is marked constant.
     #[inline]
-    pub fn entry(&mut self, k: Value) -> Result<indexmap::map::Entry<Value, Value>> {
+    pub fn entry(&mut self, k: Value) -> Result<indexmap::map::Entry<'_, Value, Value>> {
         if self.const_keys.contains(&k) {
             return Err(anyhow!("Key {k} is marked constant"));
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
