### PR TITLE
Fix flaky buildinfo test

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -80,6 +80,7 @@ jobs:
         shell: bash
         run: |
           set -e
+          rustup install --profile=minimal stable
           python3 -m venv .venv
           source .venv/bin/activate
           pip install reclass-rs --find-links dist --force-reinstall


### PR DESCRIPTION
The buildinfo Python test fails for a while after new Rust version is released until the Rust version on the CI runners is updated.

This PR adjusts the `pytest` step to run `rustup update stable` so we reliably have the latest released Rust version which should always match the version used by the maturin-action build step.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
