### PR TITLE
Fix CI issues (flaky Python tests & missing rustfmt)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          before-script-linux: |
+            rustup show active-toolchain
+            rustc --version
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -80,7 +83,14 @@ jobs:
         shell: bash
         run: |
           set -e
+          rustup show active-toolchain
+          rustc --version
           rustup install --profile=minimal stable
+          rustup show active-toolchain
+          rustc --version
+          rustup default stable
+          rustup show active-toolchain
+          rustc --version
           python3 -m venv .venv
           source .venv/bin/activate
           pip install reclass-rs --find-links dist --force-reinstall

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - run: rustup install --profile=minimal stable
+      - run: |
+          rustup install --profile=minimal stable
+          rustup component add --toolchain stable-x86_64-unknown-linux-gnu rustfmt
       - run: cargo +stable fmt --check
       - uses: actions-rs/clippy-check@v1
         with:


### PR DESCRIPTION
Follow-up for #183 to actually use updated Rust toolchain for Python tests on `x86_64`. Additionally also install missing `rustfmt` component for the "lints" GitHub workflow.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. The title will be used to auto generate the changelog
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update tests.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
      as they show up in the changelog
- [x] Link this PR to related PRs or issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
